### PR TITLE
Add Mask Rules Studio component and PropertyPathExplorer utility

### DIFF
--- a/.github/instructions/session_context.md
+++ b/.github/instructions/session_context.md
@@ -1,40 +1,49 @@
 ﻿---
 applyTo: '**'
-lastUpdated: 2026-03-18T00:00:00Z
+lastUpdated: 2026-03-19T00:00:00Z
 sessionStatus: complete
 ---
 
 # Current Session Context
 
 ## Active Task
-Add ordinal request-range support to the ComparisonTool CLI request command
+Add CLI request-response masking rules for sensitive fields
 
 ## Todo List Status
 ```markdown
-- [x] 🔍 Inspect request CLI command flow and request-file staging behavior
-- [x] 🛠️ Add validated range option and deterministic ordinal file slicing
-- [x] 🧪 Add focused CLI tests for selection, clamping, invalid input, and sidecar staging
-- [x] 📝 Update README request command usage
-- [x] ✅ Run targeted validation and review for regressions
+- [x] 🔍 Trace the CLI request-comparison flow and existing ignore-rules loading
+- [x] 🛠️ Add `--mask-rules` loading and shared mask-rule propagation
+- [x] 🛡️ Mask persisted response bodies before first write for JSON/XML request comparisons
+- [x] 🧪 Add focused CLI and masking-service tests, including UTF-16 XML coverage
+- [x] ✅ Run targeted validation and final review for leakage/regression risks
 ```
 
 ## Recent File Changes
-- `ComparisonTool.Cli/Commands/RequestCompareCommand.cs`: Added `--range`, range parsing/validation, deterministic ordinal selection, selected/total console output, and sidecar-aware staging for selected requests
-- `ComparisonTool.Cli/Properties/AssemblyInfo.cs`: Added `InternalsVisibleTo("ComparisonTool.Tests")` for focused CLI helper tests
-- `ComparisonTool.Tests/ComparisonTool.Tests.csproj`: Added a project reference to `ComparisonTool.Cli`
-- `ComparisonTool.Tests/Unit/Cli/RequestCompareCommandTests.cs`: Added tests for ordinal range behavior, invalid input handling, clamping, and staged sidecar inclusion
-- `README.md`: Documented `--range` semantics and usage example for request comparisons
+- `ComparisonTool.Cli/Commands/RequestCompareCommand.cs`: Added `--mask-rules`, mask-rule JSON loading/validation, and request-job propagation
+- `ComparisonTool.Core/RequestComparison/Models/ApiContracts.cs`: Added `MaskRuleDto` and optional `MaskRules` on the shared request contract
+- `ComparisonTool.Core/RequestComparison/Models/RequestComparisonJob.cs`: Added persisted per-job mask rules
+- `ComparisonTool.Core/RequestComparison/Services/ResponseMaskingService.cs`: Added JSON/XML string-field masking with property-path matching, charset handling, and pre-write masking support
+- `ComparisonTool.Core/RequestComparison/Services/RequestExecutionService.cs`: Masks endpoint responses before the first persisted write
+- `ComparisonTool.Core/RequestComparison/Services/RequestComparisonJobService.cs`: Validates mask rules at job creation
+- `ComparisonTool.Web/RequestComparisonApi.cs`: Returns `400` for invalid shared mask-rule input instead of surfacing a server error
+- `ComparisonTool.Cli/Infrastructure/ServiceProviderFactory.cs` and `ComparisonTool.Web/Program.cs`: Registered the masking service
+- `ComparisonTool.Tests/Unit/Cli/RequestCompareCommandTests.cs`: Added mask-rule loader tests
+- `ComparisonTool.Tests/Unit/RequestComparison/ResponseMaskingServiceTests.cs`: Added JSON, namespace-aware XML, and UTF-16 XML masking tests
+- `README.md`: Documented `--mask-rules` usage and JSON examples
 
 ## Key Technical Decisions
-- Decision: Keep the feature CLI-local by filtering files before temp-batch staging instead of changing core request-comparison contracts
-- Rationale: The request range is an operator convenience for the CLI and does not need to expand the shared API surface
-- Date: 2026-03-18
-- Decision: Apply the range after `StringComparer.Ordinal` sorting of eligible top-level request files
-- Rationale: Preserves deterministic behavior that matches the existing parser/execution ordering expectations
-- Date: 2026-03-18
-- Decision: Stage selected request files together with their matching `.headers.json` sidecars
-- Rationale: Preserves existing per-request header behavior while limiting the run to the chosen ordinal slice
-- Date: 2026-03-18
+- Decision: Use a dedicated `--mask-rules` JSON file parallel to `--ignore-rules`
+- Rationale: Keeps sensitive-value handling explicit and operator-controlled without overloading ignore semantics
+- Date: 2026-03-19
+- Decision: Mask response bodies before the first persisted write, not later in reporting
+- Rationale: Prevents masked fields from leaking into saved response files, raw-text comparisons, report payloads, and raw-content viewers
+- Date: 2026-03-19
+- Decision: Limit v1 masking to matched JSON/XML string values using the same normalized property-path style already used by comparison rules
+- Rationale: Covers payment-card and similar secrets with low deserialization risk while keeping rule syntax consistent across features
+- Date: 2026-03-19
+- Decision: Preserve charset information when masking, including UTF-16 XML payloads
+- Rationale: Avoids corrupting non-UTF8 response artifacts during masking and comparison
+- Date: 2026-03-19
 
 ## External Resources Referenced
 - Internal code inspection only
@@ -43,24 +52,25 @@ Add ordinal request-range support to the ComparisonTool CLI request command
 - [NOTE] Focused validation passed, but the repository still has many pre-existing StyleCop and analyzer warnings unrelated to this feature
 
 ## Failed Approaches
-- Approach: Initial range implementation staged only the selected primary request files
-- Failure Reason: That dropped matching `.headers.json` sidecars and would have silently removed per-request headers
-- Lesson: Range selection must keep sidecar staging aligned with the selected primary requests
+- Approach: Initial masking hook rewrote response files only after request execution completed
+- Failure Reason: That still allowed unmasked response bodies to hit disk before the masking pass
+- Lesson: Sensitive-value masking must happen before the first persisted write, not merely before comparison/reporting
 
 ## Environment Notes
 - .NET 10.0
 - Windows
 
 ## Next Session Priority
-If needed, add a command-level integration test that invokes the request command end-to-end with `--range` and verifies staged sidecars are consumed by the parser
+If needed, add a request-comparison integration test that exercises `--mask-rules` end to end against a mock endpoint and verifies masked values never reach persisted job artifacts
 
 ## Session Notes
-- Added a `--range` option that accepts 1-based inclusive values like `1-500` for the request CLI command.
-- Range selection now sorts eligible top-level `xml`/`json`/`txt` request files ordinally, clamps oversized end values, and rejects malformed or out-of-bounds starts.
-- The request comparison summary now shows the applied range and selected-versus-total request count before execution.
+- Added `--mask-rules` to the CLI request command with JSON loading that accepts both top-level arrays and `{ "maskRules": [...] }` container objects.
+- Added `MaskRuleDto` with `propertyPath`, `preserveLastCharacters`, and `maskCharacter` semantics for string-field masking.
+- Request comparison now masks matched JSON/XML response fields before the first persisted write, so downstream comparisons and reports consume masked artifacts.
+- Shared validation now rejects invalid mask rules during job creation, and the web request-comparison API maps that failure to a `400` response.
 - Validation completed:
-	- `dotnet test .\ComparisonTool.Tests\ComparisonTool.Tests.csproj --filter RequestCompareCommandTests` passed with 8/8 tests
-	- Final review found no remaining feature-level bugs after restoring sidecar-header staging for selected requests
+	- `dotnet test .\ComparisonTool.Tests\ComparisonTool.Tests.csproj --filter "RequestCompareCommandTests|ResponseMaskingServiceTests"` passed with 16/16 tests
+	- Final review confirmed the original unmasked-on-disk leak path is closed after moving masking into `RequestExecutionService`
 
 ---
 # Previous Session Archive

--- a/ComparisonTool.Cli/Commands/RequestCompareCommand.cs
+++ b/ComparisonTool.Cli/Commands/RequestCompareCommand.cs
@@ -112,6 +112,11 @@ public static partial class RequestCompareCommand
             Description = "Path to JSON file containing IgnoreRuleDto definitions",
         };
 
+        var maskRulesFileOption = new Option<FileInfo?>("--mask-rules")
+        {
+            Description = "Path to JSON file containing MaskRuleDto definitions for response masking",
+        };
+
         var contentTypeOption = new Option<string?>("--content-type")
         {
             Description = "Override Content-Type header for all request bodies",
@@ -198,6 +203,7 @@ public static partial class RequestCompareCommand
             ignoreNamespacesOption,
             semanticAnalysisOption,
             ignoreRulesFileOption,
+            maskRulesFileOption,
             contentTypeOption,
             soapActionOption,
             rangeOption,
@@ -226,6 +232,7 @@ public static partial class RequestCompareCommand
             var ignoreNamespaces = parseResult.GetValue(ignoreNamespacesOption);
             var semanticAnalysis = parseResult.GetValue(semanticAnalysisOption);
             var ignoreRulesFile = parseResult.GetValue(ignoreRulesFileOption);
+            var maskRulesFile = parseResult.GetValue(maskRulesFileOption);
             var contentTypeOverride = parseResult.GetValue(contentTypeOption);
             var soapAction = parseResult.GetValue(soapActionOption);
             var requestRange = parseResult.GetValue(rangeOption);
@@ -250,6 +257,7 @@ public static partial class RequestCompareCommand
                 ignoreNamespaces,
                 semanticAnalysis,
                 ignoreRulesFile,
+                maskRulesFile,
                 contentTypeOverride,
                 soapAction,
                 requestRange,
@@ -358,6 +366,7 @@ public static partial class RequestCompareCommand
         bool ignoreNamespaces,
         bool semanticAnalysis,
         FileInfo? ignoreRulesFile,
+        FileInfo? maskRulesFile,
         string? contentTypeOverride,
         string? soapAction,
         string? requestRange,
@@ -434,6 +443,13 @@ public static partial class RequestCompareCommand
             return 1;
         }
 
+        var maskRulesResult = await LoadMaskRulesAsync(maskRulesFile, cancellationToken);
+        if (!maskRulesResult.IsSuccess)
+        {
+            Console.Error.WriteLine(maskRulesResult.ErrorMessage);
+            return 1;
+        }
+
         var soapHeaders = string.IsNullOrWhiteSpace(soapAction)
             ? null
             : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -456,6 +472,7 @@ public static partial class RequestCompareCommand
             EnableSemanticAnalysis = semanticAnalysis,
             IgnoreRules = ignoreRulesResult.IgnoreRules,
             SmartIgnoreRules = ignoreRulesResult.SmartIgnoreRules,
+            MaskRules = maskRulesResult.MaskRules,
             ContentTypeOverride = contentTypeOverride,
             HeadersA = soapHeaders,
             HeadersB = soapHeaders,
@@ -664,6 +681,97 @@ public static partial class RequestCompareCommand
         }
     }
 
+    internal static async Task<MaskRulesLoadResult> LoadMaskRulesAsync(
+        FileInfo? fileInfo,
+        CancellationToken cancellationToken)
+    {
+        if (fileInfo == null)
+        {
+            return MaskRulesLoadResult.Success(null);
+        }
+
+        if (!fileInfo.Exists)
+        {
+            return MaskRulesLoadResult.Failure($"Mask rules file not found: {fileInfo.FullName}");
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(fileInfo.FullName, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return MaskRulesLoadResult.Success(new List<MaskRuleDto>());
+            }
+
+            List<MaskRuleDto> rules;
+            if (json.TrimStart().StartsWith("[", StringComparison.Ordinal))
+            {
+                rules = JsonSerializer.Deserialize(json, IgnoreRulesJsonContext.Default.ListMaskRuleDto) ?? new List<MaskRuleDto>();
+            }
+            else
+            {
+                var container = JsonSerializer.Deserialize(json, IgnoreRulesJsonContext.Default.MaskRulesContainer) ?? new MaskRulesContainer();
+                rules = container.MaskRules ?? new List<MaskRuleDto>();
+            }
+
+            if (rules.Any(rule => rule is null))
+            {
+                return MaskRulesLoadResult.Failure("Invalid mask rules JSON: maskRules cannot contain null entries.");
+            }
+
+            rules = rules
+                .Select(rule => string.IsNullOrWhiteSpace(rule.MaskCharacter)
+                    ? rule with { MaskCharacter = "*" }
+                    : rule)
+                .ToList();
+
+            var validationError = ValidateMaskRules(rules);
+            if (validationError != null)
+            {
+                return MaskRulesLoadResult.Failure(validationError);
+            }
+
+            return MaskRulesLoadResult.Success(rules);
+        }
+        catch (JsonException ex)
+        {
+            return MaskRulesLoadResult.Failure($"Invalid mask rules JSON: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return MaskRulesLoadResult.Failure($"Failed to read mask rules file: {ex.Message}");
+        }
+    }
+
+    private static string? ValidateMaskRules(IEnumerable<MaskRuleDto> rules)
+    {
+        foreach (var rule in rules)
+        {
+            if (rule is null)
+            {
+                return "Invalid mask rules JSON: maskRules cannot contain null entries.";
+            }
+
+            if (string.IsNullOrWhiteSpace(rule.PropertyPath))
+            {
+                return "Invalid mask rules JSON: each rule must include a non-empty propertyPath.";
+            }
+
+            if (rule.PreserveLastCharacters < 0)
+            {
+                return $"Invalid mask rules JSON: rule '{rule.PropertyPath}' has preserveLastCharacters {rule.PreserveLastCharacters}. Values must be zero or greater.";
+            }
+
+            if (string.IsNullOrWhiteSpace(rule.MaskCharacter) || rule.MaskCharacter.Length != 1)
+            {
+                return $"Invalid mask rules JSON: rule '{rule.PropertyPath}' must specify exactly one character for maskCharacter.";
+            }
+        }
+
+        return null;
+    }
+
     private sealed class IgnoreRulesContainer
     {
         public List<IgnoreRuleDto>? IgnoreRules { get; init; }
@@ -671,10 +779,17 @@ public static partial class RequestCompareCommand
         public List<SmartIgnoreRuleDto>? SmartIgnoreRules { get; init; }
     }
 
+    private sealed class MaskRulesContainer
+    {
+        public List<MaskRuleDto>? MaskRules { get; init; }
+    }
+
     [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
     [JsonSerializable(typeof(List<IgnoreRuleDto>))]
     [JsonSerializable(typeof(List<SmartIgnoreRuleDto>))]
+    [JsonSerializable(typeof(List<MaskRuleDto>))]
     [JsonSerializable(typeof(IgnoreRulesContainer))]
+    [JsonSerializable(typeof(MaskRulesContainer))]
     private sealed partial class IgnoreRulesJsonContext : JsonSerializerContext
     {
     }
@@ -701,6 +816,29 @@ public static partial class RequestCompareCommand
 
         public static IgnoreRulesLoadResult Failure(string message)
             => new IgnoreRulesLoadResult
+            {
+                IsSuccess = false,
+                ErrorMessage = message,
+            };
+    }
+
+    internal sealed record MaskRulesLoadResult
+    {
+        public bool IsSuccess { get; init; }
+
+        public string? ErrorMessage { get; init; }
+
+        public List<MaskRuleDto>? MaskRules { get; init; }
+
+        public static MaskRulesLoadResult Success(List<MaskRuleDto>? maskRules)
+            => new MaskRulesLoadResult
+            {
+                IsSuccess = true,
+                MaskRules = maskRules,
+            };
+
+        public static MaskRulesLoadResult Failure(string message)
+            => new MaskRulesLoadResult
             {
                 IsSuccess = false,
                 ErrorMessage = message,

--- a/ComparisonTool.Cli/Infrastructure/ServiceProviderFactory.cs
+++ b/ComparisonTool.Cli/Infrastructure/ServiceProviderFactory.cs
@@ -44,6 +44,7 @@ public static class ServiceProviderFactory
         services.AddSingleton<RequestFileParserService>();
         services.AddSingleton<RequestExecutionService>();
         services.AddSingleton<RawTextComparisonService>();
+        services.AddSingleton<ResponseMaskingService>();
         services.AddSingleton<IComparisonProgressPublisher, ConsoleProgressPublisher>();
         services.AddSingleton<RequestComparisonJobService>();
 

--- a/ComparisonTool.Core/RequestComparison/Models/ApiContracts.cs
+++ b/ComparisonTool.Core/RequestComparison/Models/ApiContracts.cs
@@ -61,6 +61,9 @@ public record CreateRequestComparisonJobRequest
     /// <summary>Gets the smart ignore rules to apply during comparison.</summary>
     public List<SmartIgnoreRuleDto>? SmartIgnoreRules { get; init; }
 
+    /// <summary>Gets the response masking rules to apply before comparison and reporting.</summary>
+    public List<MaskRuleDto>? MaskRules { get; init; }
+
     /// <summary>Gets a value indicating whether to enable semantic analysis.</summary>
     public bool EnableSemanticAnalysis { get; init; } = true;
 
@@ -96,6 +99,21 @@ public record SmartIgnoreRuleDto
 
     /// <summary>Gets the description for the rule.</summary>
     public string? Description { get; init; }
+}
+
+/// <summary>
+/// DTO for response masking rules in API requests.
+/// </summary>
+public record MaskRuleDto
+{
+    /// <summary>Gets the property path to mask.</summary>
+    public string PropertyPath { get; init; } = string.Empty;
+
+    /// <summary>Gets how many trailing characters should remain visible.</summary>
+    public int PreserveLastCharacters { get; init; } = 0;
+
+    /// <summary>Gets the single character used for masking.</summary>
+    public string MaskCharacter { get; init; } = "*";
 }
 
 /// <summary>

--- a/ComparisonTool.Core/RequestComparison/Models/RequestComparisonJob.cs
+++ b/ComparisonTool.Core/RequestComparison/Models/RequestComparisonJob.cs
@@ -109,6 +109,9 @@ public record RequestComparisonJob
     /// <summary>Gets or sets the smart ignore rules for this job.</summary>
     public List<SmartIgnoreRuleDto> SmartIgnoreRules { get; set; } = new();
 
+    /// <summary>Gets or sets the response masking rules for this job.</summary>
+    public List<MaskRuleDto> MaskRules { get; set; } = new();
+
     /// <summary>Gets or sets a value indicating whether semantic analysis is enabled.</summary>
     public bool EnableSemanticAnalysis { get; set; } = true;
 

--- a/ComparisonTool.Core/RequestComparison/Services/RawTextComparisonService.cs
+++ b/ComparisonTool.Core/RequestComparison/Services/RawTextComparisonService.cs
@@ -2,6 +2,8 @@ using ComparisonTool.Core.Comparison.Analysis;
 using ComparisonTool.Core.Comparison.Results;
 using ComparisonTool.Core.RequestComparison.Models;
 using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
+using System.Text;
 
 namespace ComparisonTool.Core.RequestComparison.Services;
 
@@ -75,8 +77,8 @@ public class RawTextComparisonService
         }
 
         // Read response bodies and perform line-by-line comparison
-        var bodyA = await ReadResponseBodyAsync(exec.ResponsePathA, cancellationToken).ConfigureAwait(false);
-        var bodyB = await ReadResponseBodyAsync(exec.ResponsePathB, cancellationToken).ConfigureAwait(false);
+        var bodyA = await ReadResponseBodyAsync(exec.ResponsePathA, exec.ContentTypeA, cancellationToken).ConfigureAwait(false);
+        var bodyB = await ReadResponseBodyAsync(exec.ResponsePathB, exec.ContentTypeB, cancellationToken).ConfigureAwait(false);
 
         var textDiffs = ComputeLineDifferences(bodyA.lines, bodyB.lines);
         pairResult.RawTextDifferences.AddRange(textDiffs);
@@ -159,8 +161,8 @@ public class RawTextComparisonService
     {
         var diffs = new List<RawTextDifference>();
 
-        var bodyA = await ReadResponseBodyAsync(file1Path, cancellationToken).ConfigureAwait(false);
-        var bodyB = await ReadResponseBodyAsync(file2Path, cancellationToken).ConfigureAwait(false);
+        var bodyA = await ReadResponseBodyAsync(file1Path, null, cancellationToken).ConfigureAwait(false);
+        var bodyB = await ReadResponseBodyAsync(file2Path, null, cancellationToken).ConfigureAwait(false);
 
         // If both files are missing/empty, nothing to diff
         if (bodyA.lines.Length == 0 && bodyB.lines.Length == 0)
@@ -194,6 +196,7 @@ public class RawTextComparisonService
     /// </summary>
     private static async Task<(string[] lines, bool wasTruncated)> ReadResponseBodyAsync(
         string? filePath,
+        string? contentType,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
@@ -215,10 +218,52 @@ public class RawTextComparisonService
             FileOptions.Asynchronous | FileOptions.SequentialScan);
 
         var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken).ConfigureAwait(false);
-        var text = System.Text.Encoding.UTF8.GetString(buffer, 0, bytesRead);
+        var text = DecodeText(buffer, bytesRead, contentType);
         var lines = text.Split('\n');
 
         return (lines, wasTruncated);
+    }
+
+    private static string DecodeText(byte[] buffer, int bytesRead, string? contentType)
+    {
+        var encoding = ResolveEncoding(buffer, bytesRead, contentType);
+        var text = encoding.GetString(buffer, 0, bytesRead);
+        return text.Length > 0 && text[0] == '\uFEFF'
+            ? text[1..]
+            : text;
+    }
+
+    private static Encoding ResolveEncoding(byte[] buffer, int bytesRead, string? contentType)
+    {
+        if (!string.IsNullOrWhiteSpace(contentType)
+            && MediaTypeHeaderValue.TryParse(contentType, out var header)
+            && !string.IsNullOrWhiteSpace(header.CharSet))
+        {
+            try
+            {
+                return Encoding.GetEncoding(header.CharSet.Trim('"'));
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        if (bytesRead >= 3 && buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+        {
+            return Encoding.UTF8;
+        }
+
+        if (bytesRead >= 2 && buffer[0] == 0xFF && buffer[1] == 0xFE)
+        {
+            return Encoding.Unicode;
+        }
+
+        if (bytesRead >= 2 && buffer[0] == 0xFE && buffer[1] == 0xFF)
+        {
+            return Encoding.BigEndianUnicode;
+        }
+
+        return Encoding.UTF8;
     }
 
     /// <summary>

--- a/ComparisonTool.Core/RequestComparison/Services/RequestComparisonJobService.cs
+++ b/ComparisonTool.Core/RequestComparison/Services/RequestComparisonJobService.cs
@@ -19,6 +19,7 @@ public class RequestComparisonJobService
     private readonly RequestExecutionService _executionService;
     private readonly RequestFileParserService _parserService;
     private readonly RawTextComparisonService _rawTextComparisonService;
+    private readonly ResponseMaskingService _responseMaskingService;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IComparisonProgressPublisher? _progressPublisher;
     private readonly ConcurrentDictionary<string, RequestComparisonJob> _jobs = new();
@@ -31,6 +32,7 @@ public class RequestComparisonJobService
         RequestExecutionService executionService,
         RequestFileParserService parserService,
         RawTextComparisonService rawTextComparisonService,
+        ResponseMaskingService responseMaskingService,
         IServiceScopeFactory scopeFactory,
         IComparisonProgressPublisher? progressPublisher = null)
     {
@@ -38,6 +40,7 @@ public class RequestComparisonJobService
         _executionService = executionService;
         _parserService = parserService;
         _rawTextComparisonService = rawTextComparisonService;
+        _responseMaskingService = responseMaskingService;
         _scopeFactory = scopeFactory;
         _progressPublisher = progressPublisher;
     }
@@ -115,9 +118,15 @@ public class RequestComparisonJobService
             IgnoreXmlNamespaces = request.IgnoreXmlNamespaces,
             IgnoreRules = request.IgnoreRules?.ToList() ?? new List<IgnoreRuleDto>(),
             SmartIgnoreRules = request.SmartIgnoreRules?.ToList() ?? new List<SmartIgnoreRuleDto>(),
+            MaskRules = request.MaskRules?.ToList() ?? new List<MaskRuleDto>(),
             EnableSemanticAnalysis = request.EnableSemanticAnalysis,
             EnableEnhancedStructuralAnalysis = request.EnableEnhancedStructuralAnalysis
         };
+
+        if (job.MaskRules.Count > 0)
+        {
+            _responseMaskingService.ValidateRules(job.MaskRules);
+        }
 
         _jobs[job.JobId] = job;
         _logger.LogInformation("Created request comparison job {JobId} with model {ModelName}", job.JobId, job.ModelName);

--- a/ComparisonTool.Core/RequestComparison/Services/RequestExecutionService.cs
+++ b/ComparisonTool.Core/RequestComparison/Services/RequestExecutionService.cs
@@ -15,13 +15,18 @@ public class RequestExecutionService : IDisposable
 {
     private readonly ILogger<RequestExecutionService> _logger;
     private readonly HttpClient _httpClient;
+    private readonly ResponseMaskingService _responseMaskingService;
     private readonly ArrayPool<byte> _bufferPool = ArrayPool<byte>.Shared;
     private const int BufferSize = 81920; // 80KB buffer
 
-    public RequestExecutionService(ILogger<RequestExecutionService> logger, IHttpClientFactory httpClientFactory)
+    public RequestExecutionService(
+        ILogger<RequestExecutionService> logger,
+        IHttpClientFactory httpClientFactory,
+        ResponseMaskingService responseMaskingService)
     {
         _logger = logger;
         _httpClient = httpClientFactory.CreateClient("RequestComparison");
+        _responseMaskingService = responseMaskingService;
     }
 
     /// <summary>
@@ -115,9 +120,16 @@ public class RequestExecutionService : IDisposable
             Directory.CreateDirectory(Path.GetDirectoryName(responsePathA)!);
             Directory.CreateDirectory(Path.GetDirectoryName(responsePathB)!);
 
+            var contentA = job.MaskRules.Count > 0
+                ? _responseMaskingService.MaskContent(responseA.content, responseA.contentType, responsePathA, job.MaskRules)
+                : responseA.content;
+            var contentB = job.MaskRules.Count > 0
+                ? _responseMaskingService.MaskContent(responseB.content, responseB.contentType, responsePathB, job.MaskRules)
+                : responseB.content;
+
             // Stream responses to disk
-            await SaveResponseAsync(responseA.content, responsePathA, cancellationToken).ConfigureAwait(false);
-            await SaveResponseAsync(responseB.content, responsePathB, cancellationToken).ConfigureAwait(false);
+            await SaveResponseAsync(contentA, responsePathA, cancellationToken).ConfigureAwait(false);
+            await SaveResponseAsync(contentB, responsePathB, cancellationToken).ConfigureAwait(false);
 
             stopwatch.Stop();
 
@@ -192,7 +204,7 @@ public class RequestExecutionService : IDisposable
 
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
         var content = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-        var responseContentType = response.Content.Headers.ContentType?.MediaType;
+        var responseContentType = response.Content.Headers.ContentType?.ToString();
 
         return (response.StatusCode, content, responseContentType);
     }

--- a/ComparisonTool.Core/RequestComparison/Services/ResponseMaskingService.cs
+++ b/ComparisonTool.Core/RequestComparison/Services/ResponseMaskingService.cs
@@ -1,0 +1,654 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Net.Http.Headers;
+using System.Xml;
+using System.Xml.Linq;
+using ComparisonTool.Core.RequestComparison.Models;
+using ComparisonTool.Core.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace ComparisonTool.Core.RequestComparison.Services;
+
+/// <summary>
+/// Masks configured response fields in persisted request-comparison response files.
+/// </summary>
+public sealed class ResponseMaskingService
+{
+    private readonly ILogger<ResponseMaskingService> logger;
+
+    public ResponseMaskingService(ILogger<ResponseMaskingService> logger)
+    {
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Validates mask rules and throws when they are invalid.
+    /// </summary>
+    public void ValidateRules(IReadOnlyList<MaskRuleDto> maskRules)
+    {
+        _ = NormalizeRules(maskRules);
+    }
+
+    /// <summary>
+    /// Masks response content before it is persisted to disk.
+    /// </summary>
+    public byte[] MaskContent(
+        byte[] content,
+        string? contentType,
+        string filePath,
+        IReadOnlyList<MaskRuleDto> maskRules)
+    {
+        if (content.Length == 0 || maskRules.Count == 0)
+        {
+            return content;
+        }
+
+        var normalizedRules = NormalizeRules(maskRules);
+        if (normalizedRules.Count == 0)
+        {
+            return content;
+        }
+
+        return MaskContentInternal(content, contentType, filePath, normalizedRules);
+    }
+
+    private byte[] MaskContentInternal(
+        byte[] content,
+        string? contentType,
+        string filePath,
+        IReadOnlyList<NormalizedMaskRule> normalizedRules)
+    {
+        if (content.Length == 0 || normalizedRules.Count == 0)
+        {
+            return content;
+        }
+
+        var format = DetectFormat(contentType, filePath, content);
+        return format switch
+        {
+            ResponseDocumentFormat.Json => MaskJsonContent(content, contentType, filePath, normalizedRules),
+            ResponseDocumentFormat.Xml => MaskXmlContent(content, contentType, filePath, normalizedRules),
+            _ => content,
+        };
+    }
+
+    /// <summary>
+    /// Applies mask rules to persisted response files in-place.
+    /// </summary>
+    public async Task MaskResponsesAsync(
+        IReadOnlyList<RequestExecutionResult> executionResults,
+        IReadOnlyList<MaskRuleDto> maskRules,
+        CancellationToken cancellationToken = default)
+    {
+        if (executionResults.Count == 0 || maskRules.Count == 0)
+        {
+            return;
+        }
+
+        var normalizedRules = NormalizeRules(maskRules);
+        if (normalizedRules.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var executionResult in executionResults)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await MaskFileAsync(executionResult.ResponsePathA, executionResult.ContentTypeA, normalizedRules, cancellationToken)
+                .ConfigureAwait(false);
+            await MaskFileAsync(executionResult.ResponsePathB, executionResult.ContentTypeB, normalizedRules, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static List<NormalizedMaskRule> NormalizeRules(IReadOnlyList<MaskRuleDto> maskRules)
+    {
+        var normalizedRules = new List<NormalizedMaskRule>(maskRules.Count);
+
+        foreach (var rule in maskRules)
+        {
+            if (rule is null)
+            {
+                throw new InvalidOperationException("Mask rules cannot contain null entries.");
+            }
+
+            if (string.IsNullOrWhiteSpace(rule.PropertyPath))
+            {
+                throw new InvalidOperationException("Mask rule propertyPath is required.");
+            }
+
+            if (rule.PreserveLastCharacters < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Mask rule '{rule.PropertyPath}' has an invalid preserveLastCharacters value {rule.PreserveLastCharacters}. Values must be zero or greater.");
+            }
+
+            var maskCharacter = string.IsNullOrWhiteSpace(rule.MaskCharacter)
+                ? "*"
+                : rule.MaskCharacter;
+
+            if (maskCharacter.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Mask rule '{rule.PropertyPath}' must specify exactly one maskCharacter.");
+            }
+
+            normalizedRules.Add(new NormalizedMaskRule(
+                PropertyPathNormalizer.NormalizePropertyPath(rule.PropertyPath),
+                rule.PreserveLastCharacters,
+                maskCharacter[0]));
+        }
+
+        return normalizedRules;
+    }
+
+    private async Task MaskFileAsync(
+        string? filePath,
+        string? contentType,
+        IReadOnlyList<NormalizedMaskRule> maskRules,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+        {
+            return;
+        }
+
+        var content = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
+        if (content.Length == 0)
+        {
+            return;
+        }
+
+        var maskedBytes = MaskContentInternal(content, contentType, filePath, maskRules);
+        if (maskedBytes.SequenceEqual(content))
+        {
+            return;
+        }
+
+        await File.WriteAllBytesAsync(filePath, maskedBytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ResponseDocumentFormat DetectFormat(string? contentType, string filePath, byte[] content)
+    {
+        if (!string.IsNullOrWhiteSpace(contentType))
+        {
+            if (IsJsonContentType(contentType))
+            {
+                return ResponseDocumentFormat.Json;
+            }
+
+            if (IsXmlContentType(contentType))
+            {
+                return ResponseDocumentFormat.Xml;
+            }
+        }
+
+        var sniffEncoding = ResolveEncoding(content, contentType, null);
+        var text = DecodeText(content, sniffEncoding);
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            var trimmedText = text.TrimStart();
+            if (trimmedText.Length > 0 && (trimmedText[0] == '{' || trimmedText[0] == '['))
+            {
+                return ResponseDocumentFormat.Json;
+            }
+
+            if (trimmedText.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResponseDocumentFormat.Xml;
+            }
+
+            if (trimmedText.Length > 0
+                && trimmedText[0] == '<'
+                && !trimmedText.StartsWith("<html", StringComparison.OrdinalIgnoreCase)
+                && !trimmedText.StartsWith("<!doctype html", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResponseDocumentFormat.Xml;
+            }
+        }
+
+        var extension = Path.GetExtension(filePath);
+        if (string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return ResponseDocumentFormat.Json;
+        }
+
+        if (string.Equals(extension, ".xml", StringComparison.OrdinalIgnoreCase))
+        {
+            return ResponseDocumentFormat.Xml;
+        }
+
+        return ResponseDocumentFormat.Unknown;
+    }
+
+    private byte[] MaskJsonContent(
+        byte[] content,
+        string? contentType,
+        string filePath,
+        IReadOnlyList<NormalizedMaskRule> maskRules)
+    {
+        var encoding = ResolveEncoding(content, contentType, null);
+        var text = DecodeText(content, encoding);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return content;
+        }
+
+        JsonNode? rootNode;
+
+        try
+        {
+            rootNode = JsonNode.Parse(text);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Skipping masking for invalid JSON response {FilePath}", filePath);
+            return content;
+        }
+
+        if (rootNode == null)
+        {
+            return content;
+        }
+
+        var didChange = MaskJsonNode(rootNode, string.Empty, maskRules);
+        if (!didChange)
+        {
+            return content;
+        }
+
+        var maskedContent = rootNode.ToJsonString(new JsonSerializerOptions
+        {
+            WriteIndented = ShouldWriteIndentedJson(text),
+        });
+
+        return EncodeText(maskedContent, encoding, HasByteOrderMark(content));
+    }
+
+    private byte[] MaskXmlContent(
+        byte[] content,
+        string? contentType,
+        string filePath,
+        IReadOnlyList<NormalizedMaskRule> maskRules)
+    {
+        XDocument document;
+
+        try
+        {
+            using var input = new MemoryStream(content, writable: false);
+            document = XDocument.Load(input, LoadOptions.PreserveWhitespace);
+        }
+        catch (Exception ex) when (ex is XmlException or InvalidOperationException)
+        {
+            logger.LogWarning(ex, "Skipping masking for invalid XML response {FilePath}", filePath);
+            return content;
+        }
+
+        if (document.Root == null)
+        {
+            return content;
+        }
+
+        var didChange = MaskXmlElement(document.Root, document.Root.Name.LocalName, maskRules);
+        if (!didChange)
+        {
+            return content;
+        }
+
+        var outputEncoding = ResolveEncoding(content, contentType, document.Declaration?.Encoding);
+
+        using var stream = new MemoryStream();
+        using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+        {
+            Encoding = outputEncoding,
+            Indent = false,
+            NewLineHandling = NewLineHandling.None,
+            OmitXmlDeclaration = document.Declaration == null,
+        });
+
+        document.Save(writer);
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static string DecodeText(byte[] content, Encoding encoding)
+    {
+        var text = encoding.GetString(content);
+        return text.Length > 0 && text[0] == '\uFEFF'
+            ? text[1..]
+            : text;
+    }
+
+    private static bool ShouldWriteIndentedJson(string json)
+    {
+        return json.Contains('\n', StringComparison.Ordinal) || json.Contains('\r', StringComparison.Ordinal);
+    }
+
+    private static byte[] EncodeText(string text, Encoding encoding, bool includeByteOrderMark)
+    {
+        var preamble = includeByteOrderMark ? encoding.GetPreamble() : Array.Empty<byte>();
+        var bytes = encoding.GetBytes(text);
+
+        if (preamble.Length == 0)
+        {
+            return bytes;
+        }
+
+        var result = new byte[preamble.Length + bytes.Length];
+        Buffer.BlockCopy(preamble, 0, result, 0, preamble.Length);
+        Buffer.BlockCopy(bytes, 0, result, preamble.Length, bytes.Length);
+        return result;
+    }
+
+    private static Encoding ResolveEncoding(byte[] content, string? contentType, string? xmlDeclarationEncoding)
+    {
+        if (TryGetEncodingFromContentType(contentType, out var contentTypeEncoding))
+        {
+            return contentTypeEncoding;
+        }
+
+        if (!string.IsNullOrWhiteSpace(xmlDeclarationEncoding))
+        {
+            try
+            {
+                return Encoding.GetEncoding(xmlDeclarationEncoding);
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        if (content.Length >= 4)
+        {
+            if (content[0] == 0xFF && content[1] == 0xFE && content[2] == 0x00 && content[3] == 0x00)
+            {
+                return new UTF32Encoding(false, true);
+            }
+
+            if (content[0] == 0x00 && content[1] == 0x00 && content[2] == 0xFE && content[3] == 0xFF)
+            {
+                return new UTF32Encoding(true, true);
+            }
+        }
+
+        if (content.Length >= 3 && content[0] == 0xEF && content[1] == 0xBB && content[2] == 0xBF)
+        {
+            return new UTF8Encoding(true);
+        }
+
+        if (content.Length >= 2)
+        {
+            if (content[0] == 0xFF && content[1] == 0xFE)
+            {
+                return Encoding.Unicode;
+            }
+
+            if (content[0] == 0xFE && content[1] == 0xFF)
+            {
+                return Encoding.BigEndianUnicode;
+            }
+        }
+
+        return new UTF8Encoding(false);
+    }
+
+    private static bool TryGetEncodingFromContentType(string? contentType, out Encoding encoding)
+    {
+        if (!string.IsNullOrWhiteSpace(contentType)
+            && MediaTypeHeaderValue.TryParse(contentType, out var parsed)
+            && !string.IsNullOrWhiteSpace(parsed.CharSet))
+        {
+            try
+            {
+                encoding = Encoding.GetEncoding(parsed.CharSet);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        encoding = new UTF8Encoding(false);
+        return false;
+    }
+
+    private static bool HasByteOrderMark(byte[] content)
+        => content.Length >= 2 && (
+            (content.Length >= 3 && content[0] == 0xEF && content[1] == 0xBB && content[2] == 0xBF)
+            || (content[0] == 0xFF && content[1] == 0xFE)
+            || (content[0] == 0xFE && content[1] == 0xFF)
+            || (content.Length >= 4 && content[0] == 0xFF && content[1] == 0xFE && content[2] == 0x00 && content[3] == 0x00)
+            || (content.Length >= 4 && content[0] == 0x00 && content[1] == 0x00 && content[2] == 0xFE && content[3] == 0xFF));
+
+    private static bool IsJsonContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        return contentType.Contains("json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsXmlContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        return contentType.Contains("xml", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool MaskJsonNode(
+        JsonNode node,
+        string currentPath,
+        IReadOnlyList<NormalizedMaskRule> maskRules)
+    {
+        var didChange = false;
+
+        switch (node)
+        {
+            case JsonObject jsonObject:
+                foreach (var property in jsonObject.ToList())
+                {
+                    if (property.Key == null || property.Value == null)
+                    {
+                        continue;
+                    }
+
+                    var childPath = string.IsNullOrEmpty(currentPath)
+                        ? property.Key
+                        : $"{currentPath}.{property.Key}";
+
+                    didChange |= MaskJsonNode(property.Value, childPath, maskRules);
+                }
+
+                break;
+
+            case JsonArray jsonArray:
+                for (var i = 0; i < jsonArray.Count; i++)
+                {
+                    var child = jsonArray[i];
+                    if (child == null)
+                    {
+                        continue;
+                    }
+
+                    var childPath = string.IsNullOrEmpty(currentPath)
+                        ? $"[{i}]"
+                        : $"{currentPath}[{i}]";
+
+                    didChange |= MaskJsonNode(child, childPath, maskRules);
+                }
+
+                break;
+
+            case JsonValue jsonValue when jsonValue.TryGetValue<string>(out var stringValue):
+                var matchingRule = FindMatchingRule(currentPath, maskRules);
+                if (matchingRule != null)
+                {
+                    var maskedValue = ApplyMask(stringValue, matchingRule.Value);
+                    if (!string.Equals(maskedValue, stringValue, StringComparison.Ordinal))
+                    {
+                        ReplaceJsonValue(node, maskedValue);
+                        didChange = true;
+                    }
+                }
+
+                break;
+        }
+
+        return didChange;
+    }
+
+    private static void ReplaceJsonValue(JsonNode node, string maskedValue)
+    {
+        if (node.Parent is JsonObject parentObject)
+        {
+            var property = parentObject.First(item => ReferenceEquals(item.Value, node));
+            parentObject[property.Key] = JsonValue.Create(maskedValue);
+            return;
+        }
+
+        if (node.Parent is JsonArray parentArray)
+        {
+            for (var i = 0; i < parentArray.Count; i++)
+            {
+                if (ReferenceEquals(parentArray[i], node))
+                {
+                    parentArray[i] = JsonValue.Create(maskedValue);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static bool MaskXmlElement(
+        XElement element,
+        string currentPath,
+        IReadOnlyList<NormalizedMaskRule> maskRules)
+    {
+        var didChange = false;
+
+        if (!element.Elements().Any())
+        {
+            var matchingRule = FindMatchingRule(currentPath, maskRules);
+            if (matchingRule != null && !string.IsNullOrEmpty(element.Value))
+            {
+                var maskedValue = ApplyMask(element.Value, matchingRule.Value);
+                if (!string.Equals(maskedValue, element.Value, StringComparison.Ordinal))
+                {
+                    element.Value = maskedValue;
+                    didChange = true;
+                }
+            }
+
+            return didChange;
+        }
+
+        var children = element.Elements().ToList();
+        var siblingCounts = children
+            .GroupBy(child => child.Name.LocalName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        var siblingIndexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var child in children)
+        {
+            siblingIndexes.TryGetValue(child.Name.LocalName, out var index);
+            siblingIndexes[child.Name.LocalName] = index + 1;
+
+            var segment = siblingCounts[child.Name.LocalName] > 1
+                ? $"{child.Name.LocalName}[{index}]"
+                : child.Name.LocalName;
+            var childPath = $"{currentPath}.{segment}";
+
+            didChange |= MaskXmlElement(child, childPath, maskRules);
+        }
+
+        return didChange;
+    }
+
+    private static NormalizedMaskRule? FindMatchingRule(
+        string currentPath,
+        IReadOnlyList<NormalizedMaskRule> maskRules)
+    {
+        var normalizedPath = PropertyPathNormalizer.NormalizePropertyPath(currentPath);
+        foreach (var rule in maskRules)
+        {
+            if (PathsMatch(rule.PropertyPath, normalizedPath))
+            {
+                return rule;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool PathsMatch(string rulePath, string currentPath)
+    {
+        if (string.Equals(rulePath, currentPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var ruleSegments = rulePath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var currentSegments = currentPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        if (ruleSegments.Length != currentSegments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < ruleSegments.Length; i++)
+        {
+            var ruleSegment = ruleSegments[i];
+            var currentSegment = currentSegments[i];
+
+            if (string.Equals(ruleSegment, currentSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (ruleSegment.EndsWith("[*]", StringComparison.Ordinal)
+                && string.Equals(ruleSegment[..^3], currentSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string ApplyMask(string value, NormalizedMaskRule rule)
+    {
+        if (string.IsNullOrEmpty(value) || rule.PreserveLastCharacters >= value.Length)
+        {
+            return value;
+        }
+
+        var maskedLength = value.Length - rule.PreserveLastCharacters;
+        if (rule.PreserveLastCharacters == 0)
+        {
+            return new string(rule.MaskCharacter, maskedLength);
+        }
+
+        return new string(rule.MaskCharacter, maskedLength) + value[^rule.PreserveLastCharacters..];
+    }
+
+    private readonly record struct NormalizedMaskRule(
+        string PropertyPath,
+        int PreserveLastCharacters,
+        char MaskCharacter);
+
+    private enum ResponseDocumentFormat
+    {
+        Unknown,
+        Json,
+        Xml,
+    }
+}

--- a/ComparisonTool.Tests/Unit/Cli/RequestCompareCommandTests.cs
+++ b/ComparisonTool.Tests/Unit/Cli/RequestCompareCommandTests.cs
@@ -99,6 +99,90 @@ public sealed class RequestCompareCommandTests : IDisposable
             .WithMessage("*exceeds the available eligible request file count 3*");
     }
 
+        [TestMethod]
+        public async Task LoadMaskRulesAsync_LoadsRulesFromArrayJson()
+        {
+                var file = this.CreateTempFile(
+                        "mask-rules.json",
+                        """
+                        [
+                            {
+                                "propertyPath": "Order.Payments[*].CardNumber",
+                                "preserveLastCharacters": 4
+                            }
+                        ]
+                        """);
+
+                var result = await RequestCompareCommand.LoadMaskRulesAsync(file, CancellationToken.None);
+
+                result.IsSuccess.Should().BeTrue();
+                result.MaskRules.Should().ContainSingle();
+                result.MaskRules![0].PropertyPath.Should().Be("Order.Payments[*].CardNumber");
+                result.MaskRules[0].PreserveLastCharacters.Should().Be(4);
+                result.MaskRules[0].MaskCharacter.Should().Be("*");
+        }
+
+        [TestMethod]
+        public async Task LoadMaskRulesAsync_LoadsRulesFromContainerJson()
+        {
+                var file = this.CreateTempFile(
+                        "mask-rules-container.json",
+                        """
+                        {
+                            "maskRules": [
+                                {
+                                    "propertyPath": "Order.Customer.Email",
+                                    "maskCharacter": "#"
+                                }
+                            ]
+                        }
+                        """);
+
+                var result = await RequestCompareCommand.LoadMaskRulesAsync(file, CancellationToken.None);
+
+                result.IsSuccess.Should().BeTrue();
+                result.MaskRules.Should().ContainSingle();
+                result.MaskRules![0].MaskCharacter.Should().Be("#");
+                result.MaskRules[0].PreserveLastCharacters.Should().Be(0);
+        }
+
+        [TestMethod]
+        public async Task LoadMaskRulesAsync_RejectsInvalidMaskCharacter()
+        {
+                var file = this.CreateTempFile(
+                        "mask-rules-invalid.json",
+                        """
+                        [
+                            {
+                                "propertyPath": "Order.Payments[*].CardNumber",
+                                "maskCharacter": "XX"
+                            }
+                        ]
+                        """);
+
+                var result = await RequestCompareCommand.LoadMaskRulesAsync(file, CancellationToken.None);
+
+                result.IsSuccess.Should().BeFalse();
+                result.ErrorMessage.Should().Contain("exactly one character");
+        }
+
+            [TestMethod]
+            public async Task LoadMaskRulesAsync_RejectsNullEntries()
+            {
+                var file = this.CreateTempFile(
+                    "mask-rules-null.json",
+                    """
+                    [
+                      null
+                    ]
+                    """);
+
+                var result = await RequestCompareCommand.LoadMaskRulesAsync(file, CancellationToken.None);
+
+                result.IsSuccess.Should().BeFalse();
+                result.ErrorMessage.Should().Contain("cannot contain null entries");
+            }
+
     private DirectoryInfo CreateRequestDirectory(params string[] fileNames)
     {
         var path = Path.Combine(Path.GetTempPath(), "ComparisonToolCliTests", Guid.NewGuid().ToString("N"));
@@ -111,5 +195,13 @@ public sealed class RequestCompareCommandTests : IDisposable
         }
 
         return new DirectoryInfo(path);
+    }
+
+    private FileInfo CreateTempFile(string fileName, string contents)
+    {
+        var directory = this.CreateRequestDirectory();
+        var path = Path.Combine(directory.FullName, fileName);
+        File.WriteAllText(path, contents);
+        return new FileInfo(path);
     }
 }

--- a/ComparisonTool.Tests/Unit/RequestComparison/RawTextComparisonServiceTests.cs
+++ b/ComparisonTool.Tests/Unit/RequestComparison/RawTextComparisonServiceTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Text;
 
 namespace ComparisonTool.Tests.Unit.RequestComparison;
 
@@ -47,6 +48,8 @@ public class RawTextComparisonServiceTests
         int statusB,
         string? responsePathA = null,
         string? responsePathB = null,
+        string? contentTypeA = null,
+        string? contentTypeB = null,
         bool success = true,
         string? error = null)
     {
@@ -65,6 +68,8 @@ public class RawTextComparisonServiceTests
                 StatusCodeB = statusB,
                 ResponsePathA = responsePathA,
                 ResponsePathB = responsePathB,
+                ContentTypeA = contentTypeA,
+                ContentTypeB = contentTypeB,
                 ErrorMessage = error,
             },
             Outcome = outcome,
@@ -272,6 +277,30 @@ public class RawTextComparisonServiceTests
             d.Type == RawTextDifferenceType.Modified &&
             d.TextA == "original" &&
             d.TextB == "changed");
+    }
+
+    [TestMethod]
+    public async Task CompareRawAsync_UsesDeclaredCharsetsForResponseBodies()
+    {
+        var pathA = Path.Combine(tempDir, "responseA-utf16.xml");
+        var pathB = Path.Combine(tempDir, "responseB-utf8.xml");
+        const string body = "<error>same body</error>";
+
+        await File.WriteAllTextAsync(pathA, body, Encoding.Unicode);
+        await File.WriteAllTextAsync(pathB, body, Encoding.UTF8);
+
+        var classified = CreateClassified(
+            RequestPairOutcome.StatusCodeMismatch,
+            500,
+            502,
+            responsePathA: pathA,
+            responsePathB: pathB,
+            contentTypeA: "application/xml; charset=utf-16",
+            contentTypeB: "application/xml; charset=utf-8");
+
+        var result = await service.CompareRawAsync(classified);
+
+        result.RawTextDifferences.Should().ContainSingle(diff => diff.Type == RawTextDifferenceType.StatusCodeDifference);
     }
 
     // --- CompareAllRawAsync batch tests ---

--- a/ComparisonTool.Tests/Unit/RequestComparison/ResponseMaskingServiceTests.cs
+++ b/ComparisonTool.Tests/Unit/RequestComparison/ResponseMaskingServiceTests.cs
@@ -1,0 +1,275 @@
+using System.Text;
+using System.Text.Json;
+using ComparisonTool.Core.RequestComparison.Models;
+using ComparisonTool.Core.RequestComparison.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace ComparisonTool.Tests.Unit.RequestComparison;
+
+[TestClass]
+public sealed class ResponseMaskingServiceTests : IDisposable
+{
+    private readonly List<string> createdPaths = new List<string>();
+    private readonly ResponseMaskingService service;
+
+    public ResponseMaskingServiceTests()
+    {
+        var logger = new Mock<ILogger<ResponseMaskingService>>();
+        service = new ResponseMaskingService(logger.Object);
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in createdPaths)
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task MaskResponsesAsync_MasksJsonStringValuesUsingWildcardPaths()
+    {
+        var responseFile = this.CreateTempFile(
+            "response.txt",
+            """
+            {
+              "order": {
+                "payments": [
+                  {
+                    "cardNumber": "4111111111111111",
+                    "amount": 12.34
+                  },
+                  {
+                    "cardNumber": "5555555555554444",
+                    "amount": 56.78
+                  }
+                ]
+              }
+            }
+            """);
+
+        var executionResult = CreateExecutionResult(responseFile.FullName, "application/json");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.Payments[*].CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        await service.MaskResponsesAsync(new[] { executionResult }, rules, CancellationToken.None);
+
+        var maskedJson = await File.ReadAllTextAsync(responseFile.FullName);
+        maskedJson.Should().NotContain("4111111111111111");
+        maskedJson.Should().NotContain("5555555555554444");
+        maskedJson.Should().Contain("************1111");
+        maskedJson.Should().Contain("************4444");
+
+        using var document = JsonDocument.Parse(maskedJson);
+        document.RootElement
+            .GetProperty("order")
+            .GetProperty("payments")[0]
+            .GetProperty("amount")
+            .GetDecimal()
+            .Should().Be(12.34m);
+    }
+
+    [TestMethod]
+    public async Task MaskResponsesAsync_MasksXmlLeafElementsIgnoringNamespaces()
+    {
+        var responseFile = this.CreateTempFile(
+            "response.xml",
+            """
+            <ns:Order xmlns:ns="urn:test">
+              <ns:Payment>
+                <ns:CardNumber>4111111111111111</ns:CardNumber>
+              </ns:Payment>
+              <ns:Payment>
+                <ns:CardNumber>5555555555554444</ns:CardNumber>
+              </ns:Payment>
+            </ns:Order>
+            """);
+
+        var executionResult = CreateExecutionResult(responseFile.FullName, "application/xml");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.Payment[*].CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "#",
+            },
+        };
+
+        await service.MaskResponsesAsync(new[] { executionResult }, rules, CancellationToken.None);
+
+        var maskedXml = await File.ReadAllTextAsync(responseFile.FullName);
+        maskedXml.Should().NotContain("4111111111111111");
+        maskedXml.Should().NotContain("5555555555554444");
+        maskedXml.Should().Contain("############1111");
+        maskedXml.Should().Contain("############4444");
+    }
+
+    [TestMethod]
+    public async Task MaskResponsesAsync_PreservesUtf16XmlEncoding()
+    {
+        var responseFile = this.CreateTempFile("utf16-response.xml", string.Empty);
+        var xml = """
+            <?xml version="1.0" encoding="utf-16"?>
+            <Order>
+              <Payment>
+                <CardNumber>4111111111111111</CardNumber>
+              </Payment>
+            </Order>
+            """;
+        await File.WriteAllTextAsync(responseFile.FullName, xml, Encoding.Unicode);
+
+        var executionResult = CreateExecutionResult(responseFile.FullName, "application/xml; charset=utf-16");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.Payment.CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        await service.MaskResponsesAsync(new[] { executionResult }, rules, CancellationToken.None);
+
+        var maskedXml = await File.ReadAllTextAsync(responseFile.FullName, Encoding.Unicode);
+        maskedXml.Should().Contain("************1111");
+        maskedXml.Should().NotContain("4111111111111111");
+    }
+
+    [TestMethod]
+    public async Task MaskResponsesAsync_MasksJsonWhenContentTypeIsTextPlain()
+    {
+        var responseFile = this.CreateTempFile(
+            "response.txt",
+            """
+            { "order": { "cardNumber": "4111111111111111" } }
+            """);
+
+        var executionResult = CreateExecutionResult(responseFile.FullName, "text/plain");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        await service.MaskResponsesAsync(new[] { executionResult }, rules, CancellationToken.None);
+
+        var maskedJson = await File.ReadAllTextAsync(responseFile.FullName);
+        maskedJson.Should().Contain("************1111");
+        maskedJson.Should().NotContain("4111111111111111");
+    }
+
+    [TestMethod]
+    public async Task MaskResponsesAsync_MasksSingletonXmlElementWhenRuleUsesWildcard()
+    {
+        var responseFile = this.CreateTempFile(
+            "response.xml",
+            """
+            <Order>
+              <Payment>
+                <CardNumber>4111111111111111</CardNumber>
+              </Payment>
+            </Order>
+            """);
+
+        var executionResult = CreateExecutionResult(responseFile.FullName, "application/xml");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.Payment[*].CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        await service.MaskResponsesAsync(new[] { executionResult }, rules, CancellationToken.None);
+
+        var maskedXml = await File.ReadAllTextAsync(responseFile.FullName);
+        maskedXml.Should().Contain("************1111");
+        maskedXml.Should().NotContain("4111111111111111");
+    }
+
+    [TestMethod]
+    public void MaskContent_ReturnsOriginalBytesForInvalidJson()
+    {
+        var original = Encoding.UTF8.GetBytes("<html>not json</html>");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        var masked = service.MaskContent(original, "application/json", "response.json", rules);
+
+        masked.Should().Equal(original);
+    }
+
+    [TestMethod]
+    public void MaskContent_ReturnsOriginalBytesForInvalidXml()
+    {
+        var original = Encoding.UTF8.GetBytes("{ \"not\": \"xml\" }");
+        var rules = new List<MaskRuleDto>
+        {
+            new MaskRuleDto
+            {
+                PropertyPath = "Order.Payment.CardNumber",
+                PreserveLastCharacters = 4,
+                MaskCharacter = "*",
+            },
+        };
+
+        var masked = service.MaskContent(original, "application/xml", "response.xml", rules);
+
+        masked.Should().Equal(original);
+    }
+
+    private static RequestExecutionResult CreateExecutionResult(string responsePathA, string contentTypeA)
+        => new RequestExecutionResult
+        {
+            Request = new RequestFileInfo
+            {
+                RelativePath = "request.json",
+                FilePath = responsePathA,
+                ContentType = "application/json",
+            },
+            Success = true,
+            StatusCodeA = 200,
+            StatusCodeB = 200,
+            ResponsePathA = responsePathA,
+            ContentTypeA = contentTypeA,
+        };
+
+    private FileInfo CreateTempFile(string fileName, string contents)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ComparisonToolMaskingTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        this.createdPaths.Add(path);
+
+        var filePath = Path.Combine(path, fileName);
+        File.WriteAllText(filePath, contents);
+        return new FileInfo(filePath);
+    }
+}

--- a/ComparisonTool.Web/Components/Comparison/MaskRulesStudio.razor
+++ b/ComparisonTool.Web/Components/Comparison/MaskRulesStudio.razor
@@ -1,0 +1,961 @@
+@using System.Text.Json
+@using ComparisonTool.Core.RequestComparison.Models
+@using ComparisonTool.Core.Serialization
+@using ComparisonTool.Core.Utilities
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.JSInterop
+@using MudBlazor
+
+@inject IDeserializationService DeserializationService
+@inject IJSRuntime JSRuntime
+
+<MudPaper Elevation="2" Class="pa-4">
+    <MudStack Spacing="3">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudStack Spacing="1">
+                <MudText Typo="Typo.h6">Mask Rules Studio</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Default">
+                    Build masking rules for request comparison and export them in the same JSON format supported by the CLI.
+                </MudText>
+            </MudStack>
+            <MudChip T="string" Color="Color.Info" Variant="Variant.Filled">@MaskRules.Count rule(s)</MudChip>
+        </MudStack>
+
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            Select a domain model, browse properties using the simple selector or tree navigator, then configure how many trailing characters remain visible. Prefer leaf fields that serialize to text, such as emails, card numbers, tokens, or identifiers.
+        </MudAlert>
+
+        <MudGrid Spacing="3">
+            <MudItem xs="12" md="7">
+                <MudStack Spacing="3">
+                    <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.subtitle1">Model &amp; File Actions</MudText>
+
+                            <MudSelect T="string"
+                                       Label="Select Domain Model"
+                                       Value="SelectedModelName"
+                                       ValueChanged="HandleSelectedModelChanged"
+                                       Variant="Variant.Outlined"
+                                       AnchorOrigin="Origin.BottomCenter">
+                                @foreach (var modelName in AvailableModelNames)
+                                {
+                                    <MudSelectItem Value="@modelName">@modelName</MudSelectItem>
+                                }
+                            </MudSelect>
+
+                            <MudStack Row="true" Spacing="2" Class="flex-wrap">
+                                <InputFile OnChange="HandleImportFileSelected" accept=".json" id="mask-rules-import-input" style="display: none;" />
+                                <MudButton Variant="Variant.Outlined"
+                                           StartIcon="@Icons.Material.Filled.Upload"
+                                           HtmlTag="label"
+                                           for="mask-rules-import-input">
+                                    Import Mask Rules
+                                </MudButton>
+                                <MudButton Variant="Variant.Outlined"
+                                           StartIcon="@Icons.Material.Filled.Download"
+                                           OnClick="ExportMaskRules"
+                                           Disabled="@(!MaskRules.Any())">
+                                    Export Mask Rules
+                                </MudButton>
+                                <MudButton Variant="Variant.Outlined"
+                                           Color="Color.Error"
+                                           StartIcon="@Icons.Material.Filled.DeleteSweep"
+                                           OnClick="ClearAllRules"
+                                           Disabled="@(!MaskRules.Any())">
+                                    Clear All
+                                </MudButton>
+                            </MudStack>
+
+                            @if (!string.IsNullOrEmpty(statusMessage))
+                            {
+                                <MudAlert Severity="@(statusIsError ? Severity.Error : Severity.Success)" Variant="Variant.Outlined">
+                                    @statusMessage
+                                </MudAlert>
+                            }
+                        </MudStack>
+                    </MudPaper>
+
+                    <MudTabs Rounded="true" Border="true">
+                        <MudTabPanel Text="Simple Property Selector">
+                            <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                                <MudStack Spacing="2">
+                                    <MudTextField T="string"
+                                                  @bind-Value="simpleSearchTerm"
+                                                  Label="Search Properties"
+                                                  Placeholder="customer.payment, card, token"
+                                                  Variant="Variant.Outlined"
+                                                  Immediate="true"
+                                                  Clearable="true"
+                                                  Adornment="Adornment.Start"
+                                                  AdornmentIcon="@Icons.Material.Filled.Search" />
+
+                                    <MudText Typo="Typo.caption" Color="Color.Default">
+                                        @FilteredSimpleProperties.Count property path(s) available for @SelectedModelName.
+                                    </MudText>
+
+                                    <MudPaper Elevation="0" Outlined="true" Style="max-height: 520px; overflow-y: auto;">
+                                        @if (FilteredSimpleProperties.Any())
+                                        {
+                                            @foreach (var property in FilteredSimpleProperties)
+                                            {
+                                                var isSelected = string.Equals(selectedPropertyPath, property.Path, StringComparison.Ordinal);
+                                                var existingRule = GetRule(property.Path);
+
+                                                <MudStack Row="true"
+                                                          Class="pa-2"
+                                                          Justify="Justify.SpaceBetween"
+                                                          AlignItems="AlignItems.Center"
+                                                          Style="@GetSimpleSelectionStyle(isSelected)"
+                                                          @onclick="() => SelectProperty(property.Path)">
+                                                    <MudStack Spacing="0">
+                                                        <MudText Typo="Typo.body2" Style="font-family: 'Consolas', 'Monaco', monospace; word-break: break-all;">
+                                                            @property.Path
+                                                        </MudText>
+                                                        <MudText Typo="Typo.caption" Color="Color.Default">@property.TypeName</MudText>
+                                                    </MudStack>
+                                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                                        @if (existingRule != null)
+                                                        {
+                                                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
+                                                                @GetRuleSummary(existingRule)
+                                                            </MudChip>
+                                                        }
+                                                        <MudIcon Icon="@Icons.Material.Filled.ChevronRight" Size="Size.Small" />
+                                                    </MudStack>
+                                                </MudStack>
+                                                <MudDivider />
+                                            }
+                                        }
+                                        else
+                                        {
+                                            <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center" Class="pa-6">
+                                                <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" Color="Color.Default" />
+                                                <MudText Typo="Typo.body2" Color="Color.Default">No properties match the current search.</MudText>
+                                            </MudStack>
+                                        }
+                                    </MudPaper>
+                                </MudStack>
+                            </MudPaper>
+                        </MudTabPanel>
+
+                        <MudTabPanel Text="Tree Navigator">
+                            <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                                <MudStack Spacing="2">
+                                    <MudTextField T="string"
+                                                  @bind-Value="treeSearchTerm"
+                                                  Label="Search Tree"
+                                                  Placeholder="order.payment, profile.email"
+                                                  Variant="Variant.Outlined"
+                                                  Immediate="true"
+                                                  Clearable="true"
+                                                  Adornment="Adornment.Start"
+                                                  AdornmentIcon="@Icons.Material.Filled.AccountTree" />
+
+                                    <MudStack Row="true" Spacing="1">
+                                        <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="ExpandAllTreeNodes">Expand All</MudButton>
+                                        <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="CollapseAllTreeNodes">Collapse All</MudButton>
+                                    </MudStack>
+
+                                    <MudPaper Elevation="0" Outlined="true" Style="max-height: 520px; overflow-y: auto;" Class="pa-2">
+                                        @if (treeNodes.Any())
+                                        {
+                                            @foreach (var node in treeNodes)
+                                            {
+                                                @RenderTreeNode(node, 0)
+                                            }
+                                        }
+                                        else
+                                        {
+                                            <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center" Class="pa-6">
+                                                <MudIcon Icon="@Icons.Material.Filled.AccountTree" Size="Size.Large" Color="Color.Default" />
+                                                <MudText Typo="Typo.body2" Color="Color.Default">Select a model to browse its object graph.</MudText>
+                                            </MudStack>
+                                        }
+                                    </MudPaper>
+                                </MudStack>
+                            </MudPaper>
+                        </MudTabPanel>
+                    </MudTabs>
+                </MudStack>
+            </MudItem>
+
+            <MudItem xs="12" md="5">
+                <MudStack Spacing="3">
+                    <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.subtitle1">Rule Editor</MudText>
+
+                            <MudTextField T="string"
+                                          Value="selectedPropertyPath"
+                                                        ValueChanged="HandleEditorPropertyPathChanged"
+                                          Label="Property Path"
+                                          Placeholder="OrderManagementResponse.OrderData.Payment.TransactionId"
+                                          Variant="Variant.Outlined" />
+
+                            <MudNumericField T="int"
+                                             Value="preserveLastCharacters"
+                                                            ValueChanged="HandlePreserveLastCharactersChanged"
+                                             Label="Preserve Last Characters"
+                                             Min="0"
+                                             Max="128"
+                                             Variant="Variant.Outlined" />
+
+                            <MudTextField T="string"
+                                          Value="maskCharacter"
+                                          ValueChanged="HandleMaskCharacterChanged"
+                                          Label="Mask Character"
+                                          Placeholder="*"
+                                          Variant="Variant.Outlined"
+                                          MaxLength="1"
+                                          Counter="1" />
+
+                            <MudText Typo="Typo.caption" Color="Color.Default">
+                                Preview: @GetPreviewMask()
+                            </MudText>
+
+                            <MudStack Row="true" Spacing="2">
+                                <MudButton Variant="Variant.Filled"
+                                           Color="Color.Success"
+                                           StartIcon="@Icons.Material.Filled.Add"
+                                           OnClick="SaveCurrentRule"
+                                           Disabled="@(string.IsNullOrWhiteSpace(selectedPropertyPath))">
+                                    Add Or Update Rule
+                                </MudButton>
+                                <MudButton Variant="Variant.Text"
+                                           Color="Color.Default"
+                                           OnClick="ResetEditor">
+                                    Reset
+                                </MudButton>
+                            </MudStack>
+                        </MudStack>
+                    </MudPaper>
+
+                    <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                        <MudStack Spacing="2">
+                            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                                <MudText Typo="Typo.subtitle1">Current Mask Rules</MudText>
+                                <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">@MaskRules.Count</MudChip>
+                            </MudStack>
+
+                            @if (MaskRules.Any())
+                            {
+                                <MudPaper Elevation="0" Outlined="true" Style="max-height: 520px; overflow-y: auto;">
+                                    @foreach (var rule in OrderedRules)
+                                    {
+                                        <MudStack Spacing="2" Class="pa-3">
+                                            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Start">
+                                                <MudText Typo="Typo.body2" Style="font-family: 'Consolas', 'Monaco', monospace; word-break: break-all;">
+                                                    @rule.PropertyPath
+                                                </MudText>
+                                                <MudStack Row="true" Spacing="0">
+                                                    <MudTooltip Text="Edit rule">
+                                                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                                                       Size="Size.Small"
+                                                                       Color="Color.Primary"
+                                                                       OnClick="() => EditRule(rule)" />
+                                                    </MudTooltip>
+                                                    <MudTooltip Text="Remove rule">
+                                                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                                       Size="Size.Small"
+                                                                       Color="Color.Error"
+                                                                       OnClick="() => RemoveRule(rule.PropertyPath)" />
+                                                    </MudTooltip>
+                                                </MudStack>
+                                            </MudStack>
+
+                                            <MudGrid Spacing="2">
+                                                <MudItem xs="6">
+                                                    <MudNumericField T="int"
+                                                                     Value="rule.PreserveLastCharacters"
+                                                                     ValueChanged="value => UpdateRule(rule with { PreserveLastCharacters = value })"
+                                                                     Label="Preserve"
+                                                                     Min="0"
+                                                                     Max="128"
+                                                                     Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="6">
+                                                    <MudTextField T="string"
+                                                                  Value="rule.MaskCharacter"
+                                                                  ValueChanged="value => UpdateRule(rule with { MaskCharacter = NormalizeMaskCharacter(value) })"
+                                                                  Label="Mask"
+                                                                      Variant="Variant.Outlined"
+                                                                  MaxLength="1"
+                                                                  Counter="1" />
+                                                </MudItem>
+                                            </MudGrid>
+
+                                            <MudText Typo="Typo.caption" Color="Color.Default">
+                                                Sample: @GetPreviewMask(rule)
+                                            </MudText>
+                                        </MudStack>
+                                        <MudDivider />
+                                    }
+                                </MudPaper>
+                            }
+                            else
+                            {
+                                <MudAlert Severity="Severity.Normal" Variant="Variant.Outlined">
+                                    No mask rules configured yet.
+                                </MudAlert>
+                            }
+                        </MudStack>
+                    </MudPaper>
+                </MudStack>
+            </MudItem>
+        </MudGrid>
+    </MudStack>
+</MudPaper>
+
+@code {
+    [Parameter] public IEnumerable<string> AvailableModelNames { get; set; } = Array.Empty<string>();
+    [Parameter] public string? SelectedModelName { get; set; }
+    [Parameter] public EventCallback<string> SelectedModelNameChanged { get; set; }
+    [Parameter] public List<MaskRuleDto> MaskRules { get; set; } = new();
+    [Parameter] public EventCallback<List<MaskRuleDto>> MaskRulesChanged { get; set; }
+
+    private const string SampleValue = "4111111111111111";
+
+    private readonly JsonSerializerOptions serializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly List<TreeNode> treeNodes = new();
+    private readonly HashSet<string> expandedNodes = new(StringComparer.Ordinal);
+    private Dictionary<string, Type> allPropertyPaths = new(StringComparer.Ordinal);
+
+    private string simpleSearchTerm = string.Empty;
+    private string treeSearchTerm = string.Empty;
+    private string? selectedPropertyPath;
+    private int preserveLastCharacters = 4;
+    private string maskCharacter = "*";
+    private string statusMessage = string.Empty;
+    private bool statusIsError;
+
+    private List<PropertyEntry> FilteredSimpleProperties => allPropertyPaths
+        .OrderBy(path => path.Key, StringComparer.Ordinal)
+        .Where(path => IsMaskCandidatePath(path.Key, path.Value))
+        .Where(path => string.IsNullOrWhiteSpace(simpleSearchTerm)
+            || path.Key.Contains(simpleSearchTerm, StringComparison.OrdinalIgnoreCase))
+        .Select(path => new PropertyEntry(path.Key, PropertyPathExplorer.GetFriendlyTypeName(path.Value)))
+        .ToList();
+
+    private List<MaskRuleDto> OrderedRules => MaskRules
+        .OrderBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    protected override void OnParametersSet()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedModelName))
+        {
+            var fallbackModel = AvailableModelNames.FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(fallbackModel))
+            {
+                SelectedModelName = fallbackModel;
+            }
+        }
+
+        LoadPropertyMetadata();
+    }
+
+    private async Task HandleSelectedModelChanged(string modelName)
+    {
+        SelectedModelName = modelName;
+        ResetEditor();
+        LoadPropertyMetadata();
+        await SelectedModelNameChanged.InvokeAsync(modelName);
+    }
+
+    private void LoadPropertyMetadata()
+    {
+        allPropertyPaths = new Dictionary<string, Type>(StringComparer.Ordinal);
+        treeNodes.Clear();
+        expandedNodes.Clear();
+
+        if (string.IsNullOrWhiteSpace(SelectedModelName))
+        {
+            return;
+        }
+
+        Type? modelType;
+        try
+        {
+            modelType = DeserializationService.GetModelType(SelectedModelName);
+        }
+        catch
+        {
+            modelType = null;
+        }
+
+        allPropertyPaths = PropertyPathExplorer.GetAllPropertyPaths(modelType);
+        BuildTree();
+    }
+
+    private void BuildTree()
+    {
+        foreach (var property in allPropertyPaths)
+        {
+            AddTreePath(property.Key, property.Value);
+        }
+
+        foreach (var node in treeNodes)
+        {
+            if (node.Children.Count > 0)
+            {
+                expandedNodes.Add(node.FullPath);
+            }
+        }
+    }
+
+    private void AddTreePath(string propertyPath, Type propertyType)
+    {
+        var segments = SplitPropertyPath(propertyPath);
+        var currentLevel = treeNodes;
+        var currentPath = string.Empty;
+
+        for (var index = 0; index < segments.Count; index++)
+        {
+            var segment = segments[index];
+            currentPath = string.IsNullOrEmpty(currentPath)
+                ? segment
+                : segment == "[*]"
+                    ? $"{currentPath}[*]"
+                    : $"{currentPath}.{segment}";
+
+            var node = currentLevel.FirstOrDefault(existing => string.Equals(existing.Name, segment, StringComparison.Ordinal));
+            if (node == null)
+            {
+                var isLeaf = index == segments.Count - 1;
+                node = new TreeNode
+                {
+                    Name = segment,
+                    FullPath = currentPath,
+                    PropertyType = isLeaf ? propertyType : null,
+                    IsCollection = isLeaf && PropertyPathExplorer.IsCollectionType(propertyType),
+                    IsLeaf = isLeaf
+                };
+
+                currentLevel.Add(node);
+            }
+
+            currentLevel = node.Children;
+        }
+    }
+
+    private static List<string> SplitPropertyPath(string propertyPath)
+    {
+        var segments = new List<string>();
+        var parts = propertyPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var part in parts)
+        {
+            if (!part.Contains("[*]", StringComparison.Ordinal))
+            {
+                segments.Add(part);
+                continue;
+            }
+
+            var itemStart = part.IndexOf("[*]", StringComparison.Ordinal);
+            var before = part[..itemStart];
+            if (!string.IsNullOrEmpty(before))
+            {
+                segments.Add(before);
+            }
+
+            segments.Add("[*]");
+
+            var after = part[(itemStart + 3)..];
+            if (!string.IsNullOrEmpty(after))
+            {
+                segments.Add(after);
+            }
+        }
+
+        return segments;
+    }
+
+    private void SelectProperty(string propertyPath)
+    {
+        selectedPropertyPath = propertyPath;
+
+        var existingRule = GetRule(propertyPath);
+        if (existingRule != null)
+        {
+            preserveLastCharacters = existingRule.PreserveLastCharacters;
+            maskCharacter = existingRule.MaskCharacter;
+        }
+    }
+
+    private void HandleTreeNodeClick(TreeNode node)
+    {
+        if (node.PropertyType != null && IsMaskCandidatePath(node.FullPath, node.PropertyType))
+        {
+            SelectProperty(node.FullPath);
+            return;
+        }
+
+        if (node.Children.Count > 0)
+        {
+            ToggleExpanded(node);
+        }
+    }
+
+    private void HandleEditorPropertyPathChanged(string? value)
+    {
+        selectedPropertyPath = value;
+    }
+
+    private void HandlePreserveLastCharactersChanged(int value)
+    {
+        preserveLastCharacters = value;
+    }
+
+    private async Task SaveCurrentRule()
+    {
+        statusMessage = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(selectedPropertyPath))
+        {
+            SetStatus("Select or enter a property path first.", true);
+            return;
+        }
+
+        if (preserveLastCharacters < 0)
+        {
+            SetStatus("Preserve last characters must be zero or greater.", true);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(maskCharacter) || maskCharacter.Length != 1)
+        {
+            SetStatus("Mask character must be exactly one character.", true);
+            return;
+        }
+
+        var normalizedPath = PropertyPathNormalizer.NormalizePropertyPath(selectedPropertyPath.Trim());
+        if (allPropertyPaths.TryGetValue(normalizedPath, out var propertyType)
+            && !IsMaskCandidatePath(normalizedPath, propertyType))
+        {
+            SetStatus("Select a terminal value field. Container and collection paths cannot be masked directly.", true);
+            return;
+        }
+
+        var updatedRule = new MaskRuleDto
+        {
+            PropertyPath = normalizedPath,
+            PreserveLastCharacters = preserveLastCharacters,
+            MaskCharacter = maskCharacter
+        };
+
+        var updatedRules = MaskRules
+            .Where(rule => !string.Equals(rule.PropertyPath, normalizedPath, StringComparison.OrdinalIgnoreCase))
+            .Append(updatedRule)
+            .OrderBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        MaskRules = updatedRules;
+        selectedPropertyPath = normalizedPath;
+        await MaskRulesChanged.InvokeAsync(updatedRules);
+
+        SetStatus($"Saved mask rule for '{normalizedPath}'.", false);
+    }
+
+    private async Task UpdateRule(MaskRuleDto updatedRule)
+    {
+        if (updatedRule.PreserveLastCharacters < 0)
+        {
+            SetStatus("Preserve last characters must be zero or greater.", true);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(updatedRule.MaskCharacter) || updatedRule.MaskCharacter.Length != 1)
+        {
+            SetStatus("Mask character must be exactly one character.", true);
+            return;
+        }
+
+        var normalizedRule = updatedRule with
+        {
+            PropertyPath = PropertyPathNormalizer.NormalizePropertyPath(updatedRule.PropertyPath),
+            MaskCharacter = NormalizeMaskCharacter(updatedRule.MaskCharacter)
+        };
+
+        var updatedRules = MaskRules
+            .Select(rule => string.Equals(rule.PropertyPath, normalizedRule.PropertyPath, StringComparison.OrdinalIgnoreCase) ? normalizedRule : rule)
+            .OrderBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        MaskRules = updatedRules;
+        await MaskRulesChanged.InvokeAsync(updatedRules);
+        SetStatus($"Updated '{normalizedRule.PropertyPath}'.", false);
+    }
+
+    private async Task RemoveRule(string propertyPath)
+    {
+        var updatedRules = MaskRules
+            .Where(rule => !string.Equals(rule.PropertyPath, propertyPath, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        MaskRules = updatedRules;
+        if (string.Equals(selectedPropertyPath, propertyPath, StringComparison.Ordinal))
+        {
+            ResetEditor();
+        }
+
+        await MaskRulesChanged.InvokeAsync(updatedRules);
+        SetStatus($"Removed '{propertyPath}'.", false);
+    }
+
+    private async Task ClearAllRules()
+    {
+        MaskRules = new List<MaskRuleDto>();
+        ResetEditor();
+        await MaskRulesChanged.InvokeAsync(MaskRules);
+        SetStatus("Cleared all mask rules.", false);
+    }
+
+    private void EditRule(MaskRuleDto rule)
+    {
+        selectedPropertyPath = rule.PropertyPath;
+        preserveLastCharacters = rule.PreserveLastCharacters;
+        maskCharacter = rule.MaskCharacter;
+    }
+
+    private void ResetEditor()
+    {
+        selectedPropertyPath = string.Empty;
+        preserveLastCharacters = 4;
+        maskCharacter = "*";
+    }
+
+    private string GetPreviewMask()
+    {
+        return GetPreviewMask(new MaskRuleDto
+        {
+            PropertyPath = selectedPropertyPath ?? string.Empty,
+            PreserveLastCharacters = preserveLastCharacters,
+            MaskCharacter = NormalizeMaskCharacter(maskCharacter)
+        });
+    }
+
+    private static string GetPreviewMask(MaskRuleDto rule)
+    {
+        if (rule.PreserveLastCharacters >= SampleValue.Length)
+        {
+            return SampleValue;
+        }
+
+        var mask = string.IsNullOrWhiteSpace(rule.MaskCharacter) ? "*" : rule.MaskCharacter;
+        var visibleCharacters = Math.Clamp(rule.PreserveLastCharacters, 0, SampleValue.Length);
+        var maskedLength = SampleValue.Length - visibleCharacters;
+
+        return visibleCharacters == 0
+            ? new string(mask[0], maskedLength)
+            : new string(mask[0], maskedLength) + SampleValue[^visibleCharacters..];
+    }
+
+    private async Task ExportMaskRules()
+    {
+        try
+        {
+            var payload = new MaskRuleFileContainer
+            {
+                MaskRules = OrderedRules
+            };
+
+            var json = JsonSerializer.Serialize(payload, serializerOptions);
+            var fileName = $"mask-rules_{DateTime.Now:yyyyMMdd_HHmmss}.json";
+            await JSRuntime.InvokeVoidAsync("saveAsFile", fileName, "application/json", json);
+
+            SetStatus($"Exported {MaskRules.Count} mask rule(s).", false);
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Export failed: {ex.Message}", true);
+        }
+    }
+
+    private async Task HandleImportFileSelected(InputFileChangeEventArgs args)
+    {
+        statusMessage = string.Empty;
+
+        var file = args.File;
+        if (file == null)
+        {
+            SetStatus("No file selected.", true);
+            return;
+        }
+
+        if (!file.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            SetStatus("Select a .json file.", true);
+            return;
+        }
+
+        const long maxFileSize = 1024 * 1024;
+        if (file.Size > maxFileSize)
+        {
+            SetStatus("Mask-rule files must be 1 MB or smaller.", true);
+            return;
+        }
+
+        try
+        {
+            await using var stream = file.OpenReadStream(maxFileSize);
+            using var reader = new StreamReader(stream);
+            var json = await reader.ReadToEndAsync();
+
+            var importedRules = TryDeserializeMaskRules(json);
+            if (importedRules.Count == 0)
+            {
+                SetStatus("The selected file does not contain any valid mask rules.", true);
+                return;
+            }
+
+            var normalizedRules = importedRules
+                .Where(rule => rule != null)
+                .Select(rule => rule!)
+                .Where(rule => !string.IsNullOrWhiteSpace(rule.PropertyPath))
+                .Select(rule => new MaskRuleDto
+                {
+                    PropertyPath = PropertyPathNormalizer.NormalizePropertyPath(rule.PropertyPath.Trim()),
+                    PreserveLastCharacters = Math.Max(0, rule.PreserveLastCharacters),
+                    MaskCharacter = NormalizeMaskCharacter(rule.MaskCharacter)
+                })
+                .GroupBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.Last())
+                .OrderBy(rule => rule.PropertyPath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (normalizedRules.Any(rule => string.IsNullOrWhiteSpace(rule.MaskCharacter) || rule.MaskCharacter.Length != 1))
+            {
+                SetStatus("Every imported mask rule must specify exactly one mask character.", true);
+                return;
+            }
+
+            MaskRules = normalizedRules;
+            await MaskRulesChanged.InvokeAsync(normalizedRules);
+            SetStatus($"Imported {normalizedRules.Count} mask rule(s).", false);
+        }
+        catch (JsonException ex)
+        {
+            SetStatus($"Import failed: invalid JSON. {ex.Message}", true);
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Import failed: {ex.Message}", true);
+        }
+    }
+
+    private List<MaskRuleDto> TryDeserializeMaskRules(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        if (document.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            var directList = JsonSerializer.Deserialize<List<MaskRuleDto?>>(json, serializerOptions);
+            if (directList == null)
+            {
+                return new List<MaskRuleDto>();
+            }
+
+            return directList.Where(rule => rule != null).Select(rule => rule!).ToList();
+        }
+
+        var container = JsonSerializer.Deserialize<MaskRuleFileContainer>(json, serializerOptions);
+        return container?.MaskRules?.Where(rule => rule != null).Select(rule => rule!).ToList() ?? new List<MaskRuleDto>();
+    }
+
+    private string NormalizeMaskCharacter(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "*" : value[..1];
+    }
+
+    private static string GetSimpleSelectionStyle(bool isSelected)
+    {
+        return isSelected
+            ? "cursor: pointer; background-color: var(--mud-palette-primary-lighten);"
+            : "cursor: pointer; background-color: transparent;";
+    }
+
+    private static string GetTreeNodeStyle(int depth, bool isSelected)
+    {
+        var background = isSelected ? "var(--mud-palette-primary-lighten)" : "transparent";
+        return $"padding-left: {depth * 18}px; cursor: pointer; background-color: {background};";
+    }
+
+    private void HandleMaskCharacterChanged(string value)
+    {
+        maskCharacter = NormalizeMaskCharacter(value);
+    }
+
+    private void SetStatus(string message, bool isError)
+    {
+        statusMessage = message;
+        statusIsError = isError;
+    }
+
+    private MaskRuleDto? GetRule(string propertyPath)
+    {
+        var normalizedPath = PropertyPathNormalizer.NormalizePropertyPath(propertyPath);
+        return MaskRules.FirstOrDefault(rule => string.Equals(rule.PropertyPath, normalizedPath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private string GetRuleSummary(MaskRuleDto rule)
+    {
+        return $"keep {rule.PreserveLastCharacters}, mask '{rule.MaskCharacter}'";
+    }
+
+    private void ExpandAllTreeNodes()
+    {
+        foreach (var node in FlattenTree(treeNodes))
+        {
+            if (node.Children.Count > 0)
+            {
+                expandedNodes.Add(node.FullPath);
+            }
+        }
+    }
+
+    private void CollapseAllTreeNodes()
+    {
+        expandedNodes.Clear();
+    }
+
+    private IEnumerable<TreeNode> FlattenTree(IEnumerable<TreeNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            yield return node;
+
+            foreach (var child in FlattenTree(node.Children))
+            {
+                yield return child;
+            }
+        }
+    }
+
+    private bool IsExpanded(TreeNode node)
+    {
+        return expandedNodes.Contains(node.FullPath);
+    }
+
+    private void ToggleExpanded(TreeNode node)
+    {
+        if (!expandedNodes.Add(node.FullPath))
+        {
+            expandedNodes.Remove(node.FullPath);
+        }
+    }
+
+    private bool NodeMatchesFilter(TreeNode node)
+    {
+        if (string.IsNullOrWhiteSpace(treeSearchTerm))
+        {
+            return true;
+        }
+
+        if (node.FullPath.Contains(treeSearchTerm, StringComparison.OrdinalIgnoreCase)
+            || node.Name.Contains(treeSearchTerm, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return node.Children.Any(NodeMatchesFilter);
+    }
+
+    private bool IsMaskCandidatePath(string path, Type propertyType)
+    {
+        return !PropertyPathExplorer.IsCollectionType(propertyType)
+            && !HasDescendantPath(path);
+    }
+
+    private bool HasDescendantPath(string path)
+    {
+        var prefixWithDot = $"{path}.";
+        var prefixWithIndex = $"{path}[";
+
+        return allPropertyPaths.Keys.Any(existingPath =>
+            existingPath.Length > path.Length
+            && (existingPath.StartsWith(prefixWithDot, StringComparison.Ordinal)
+                || existingPath.StartsWith(prefixWithIndex, StringComparison.Ordinal)));
+    }
+
+    private RenderFragment RenderTreeNode(TreeNode node, int depth) => @<div>
+        @if (NodeMatchesFilter(node))
+        {
+            var isSelected = string.Equals(selectedPropertyPath, node.FullPath, StringComparison.Ordinal);
+            var existingRule = GetRule(node.FullPath);
+            var isSelectable = node.PropertyType != null && IsMaskCandidatePath(node.FullPath, node.PropertyType);
+
+            <MudStack Row="true"
+                      AlignItems="AlignItems.Center"
+                      Justify="Justify.SpaceBetween"
+                      Class="pa-1"
+                      Style="@GetTreeNodeStyle(depth, isSelected)"
+                      @onclick="() => HandleTreeNodeClick(node)">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    @if (node.Children.Count > 0)
+                    {
+                        <div @onclick:stopPropagation="true">
+                            <MudIconButton Icon="@(IsExpanded(node) ? Icons.Material.Filled.ExpandMore : Icons.Material.Filled.ChevronRight)"
+                                           Size="Size.Small"
+                                           OnClick="() => ToggleExpanded(node)" />
+                        </div>
+                    }
+                    else
+                    {
+                        <MudIcon Icon="@(node.IsCollection ? Icons.Material.Filled.List : Icons.Material.Filled.DragIndicator)" Size="Size.Small" />
+                    }
+
+                    <MudText Typo="Typo.body2" Style="font-family: 'Consolas', 'Monaco', monospace;">
+                        @node.Name
+                    </MudText>
+                    @if (node.PropertyType != null)
+                    {
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@PropertyPathExplorer.GetFriendlyTypeName(node.PropertyType)</MudChip>
+                    }
+                    @if (!isSelectable && node.Children.Count > 0)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Container</MudChip>
+                    }
+                </MudStack>
+
+                @if (existingRule != null)
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
+                        @GetRuleSummary(existingRule)
+                    </MudChip>
+                }
+            </MudStack>
+
+            @if (node.Children.Count > 0 && (IsExpanded(node) || !string.IsNullOrWhiteSpace(treeSearchTerm)))
+            {
+                @foreach (var child in node.Children.OrderBy(child => child.Name, StringComparer.Ordinal))
+                {
+                    @RenderTreeNode(child, depth + 1)
+                }
+            }
+        }
+    </div>;
+
+    private sealed record PropertyEntry(string Path, string TypeName);
+
+    private sealed class TreeNode
+    {
+        public string Name { get; set; } = string.Empty;
+        public string FullPath { get; set; } = string.Empty;
+        public Type? PropertyType { get; set; }
+        public bool IsCollection { get; set; }
+        public bool IsLeaf { get; set; }
+        public List<TreeNode> Children { get; } = new();
+    }
+
+    private sealed class MaskRuleFileContainer
+    {
+        public List<MaskRuleDto?> MaskRules { get; set; } = new();
+    }
+}

--- a/ComparisonTool.Web/Components/Comparison/PropertyPathExplorer.cs
+++ b/ComparisonTool.Web/Components/Comparison/PropertyPathExplorer.cs
@@ -1,0 +1,250 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+
+namespace ComparisonTool.Web.Components.Comparison;
+
+internal static class PropertyPathExplorer
+{
+    private const int MaxDepth = 8;
+
+    public static Dictionary<string, Type> GetAllPropertyPaths(
+        Type? type,
+        string basePath = "",
+        int depth = 0,
+        HashSet<Type>? visitedTypes = null)
+    {
+        var result = new Dictionary<string, Type>(StringComparer.Ordinal);
+
+        if (type == null)
+        {
+            return result;
+        }
+
+        visitedTypes ??= new HashSet<Type>();
+        var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+        var preferXmlNames = HasXmlMetadata(effectiveType);
+
+        if (depth > MaxDepth || visitedTypes.Contains(effectiveType))
+        {
+            return result;
+        }
+
+        visitedTypes.Add(effectiveType);
+
+        foreach (var property in effectiveType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || ShouldIgnore(property))
+            {
+                continue;
+            }
+
+            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+            var segmentName = GetSerializedPropertyName(property, preferXmlNames);
+            if (string.IsNullOrWhiteSpace(segmentName))
+            {
+                continue;
+            }
+
+            var prefix = basePath;
+            if (depth == 0 && string.IsNullOrEmpty(prefix))
+            {
+                prefix = GetRootPathPrefix(effectiveType, preferXmlNames);
+            }
+
+            var path = string.IsNullOrEmpty(prefix)
+                ? segmentName
+                : $"{prefix}.{segmentName}";
+
+            result[path] = propertyType;
+
+            if (IsCollectionType(propertyType))
+            {
+                var itemType = GetCollectionElementType(propertyType);
+                var itemPath = GetCollectionItemPath(path, property, itemType, preferXmlNames);
+                if (itemType != null)
+                {
+                    result[itemPath] = itemType;
+
+                    if (!IsPrimitiveType(itemType))
+                    {
+                        var childPaths = GetAllPropertyPaths(itemType, itemPath, depth + 1, new HashSet<Type>(visitedTypes));
+                        foreach (var child in childPaths)
+                        {
+                            result[child.Key] = child.Value;
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            if (!IsPrimitiveType(propertyType) && propertyType != typeof(string))
+            {
+                var childPaths = GetAllPropertyPaths(propertyType, path, depth + 1, new HashSet<Type>(visitedTypes));
+                foreach (var child in childPaths)
+                {
+                    result[child.Key] = child.Value;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static bool IsPrimitiveType(Type? type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+
+        return effectiveType.IsPrimitive
+            || effectiveType.IsEnum
+            || effectiveType == typeof(string)
+            || effectiveType == typeof(decimal)
+            || effectiveType == typeof(DateTime)
+            || effectiveType == typeof(DateTimeOffset)
+            || effectiveType == typeof(Guid)
+            || effectiveType == typeof(TimeSpan);
+    }
+
+    public static bool IsCollectionType(Type? type)
+    {
+        if (type == null || type == typeof(string))
+        {
+            return false;
+        }
+
+        return typeof(IEnumerable).IsAssignableFrom(type);
+    }
+
+    public static Type? GetCollectionElementType(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        if (type.IsGenericType)
+        {
+            return type.GetGenericArguments().FirstOrDefault();
+        }
+
+        var enumerableInterface = type
+            .GetInterfaces()
+            .FirstOrDefault(interfaceType => interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        return enumerableInterface?.GetGenericArguments().FirstOrDefault();
+    }
+
+    public static string GetFriendlyTypeName(Type? type)
+    {
+        if (type == null)
+        {
+            return "Unknown";
+        }
+
+        var effectiveType = Nullable.GetUnderlyingType(type);
+        if (effectiveType != null)
+        {
+            return $"{GetFriendlyTypeName(effectiveType)}?";
+        }
+
+        if (type.IsArray)
+        {
+            return $"{GetFriendlyTypeName(type.GetElementType())}[]";
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+        {
+            return $"List<{GetFriendlyTypeName(type.GetGenericArguments()[0])}>";
+        }
+
+        return type.Name switch
+        {
+            nameof(String) => "string",
+            nameof(Int32) => "int",
+            nameof(Int64) => "long",
+            nameof(Boolean) => "bool",
+            nameof(Decimal) => "decimal",
+            nameof(Double) => "double",
+            nameof(Single) => "float",
+            nameof(DateTime) => "DateTime",
+            nameof(DateTimeOffset) => "DateTimeOffset",
+            _ => type.Name
+        };
+    }
+
+    private static bool HasXmlMetadata(MemberInfo member)
+    {
+        return member.GetCustomAttribute<XmlRootAttribute>() != null
+            || member.GetCustomAttribute<XmlElementAttribute>() != null
+            || member.GetCustomAttribute<XmlArrayAttribute>() != null
+            || member.GetCustomAttribute<XmlArrayItemAttribute>() != null
+            || member.GetCustomAttribute<XmlAttributeAttribute>() != null;
+    }
+
+    private static bool ShouldIgnore(PropertyInfo property)
+    {
+        return property.GetCustomAttribute<JsonIgnoreAttribute>() != null
+            || property.GetCustomAttribute<XmlIgnoreAttribute>() != null;
+    }
+
+    private static string GetRootPathPrefix(Type type, bool preferXmlNames)
+    {
+        if (!preferXmlNames)
+        {
+            return string.Empty;
+        }
+
+        var rootAttribute = type.GetCustomAttribute<XmlRootAttribute>();
+        return string.IsNullOrWhiteSpace(rootAttribute?.ElementName)
+            ? type.Name
+            : rootAttribute.ElementName;
+    }
+
+    private static string GetSerializedPropertyName(PropertyInfo property, bool preferXmlNames)
+    {
+        if (preferXmlNames)
+        {
+            var xmlAttribute = property.GetCustomAttribute<XmlAttributeAttribute>();
+            if (xmlAttribute != null)
+            {
+                return string.Empty;
+            }
+
+            var xmlArray = property.GetCustomAttribute<XmlArrayAttribute>();
+            if (!string.IsNullOrWhiteSpace(xmlArray?.ElementName))
+            {
+                return xmlArray.ElementName;
+            }
+
+            var xmlElement = property.GetCustomAttribute<XmlElementAttribute>();
+            if (!string.IsNullOrWhiteSpace(xmlElement?.ElementName))
+            {
+                return xmlElement.ElementName;
+            }
+        }
+
+        var jsonName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+        return string.IsNullOrWhiteSpace(jsonName) ? property.Name : jsonName;
+    }
+
+    private static string GetCollectionItemPath(string path, PropertyInfo property, Type? itemType, bool preferXmlNames)
+    {
+        if (preferXmlNames)
+        {
+            var xmlItem = property.GetCustomAttribute<XmlArrayItemAttribute>();
+            if (!string.IsNullOrWhiteSpace(xmlItem?.ElementName))
+            {
+                return $"{path}.{xmlItem.ElementName}[*]";
+            }
+        }
+
+        return $"{path}[*]";
+    }
+}

--- a/ComparisonTool.Web/Components/Comparison/RequestComparisonPanel.razor
+++ b/ComparisonTool.Web/Components/Comparison/RequestComparisonPanel.razor
@@ -74,7 +74,7 @@
                 <MudSelect T="string" 
                            Label="Select Domain Model" 
                            Value="selectedModelName"
-                           ValueChanged="@((string val) => selectedModelName = val)"
+                           ValueChanged="HandleSelectedModelChanged"
                            Variant="Variant.Outlined"
                            AnchorOrigin="Origin.BottomCenter">
                     @foreach (var modelName in availableModels)
@@ -82,6 +82,10 @@
                         <MudSelectItem Value="@modelName">@modelName</MudSelectItem>
                     }
                 </MudSelect>
+
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true">
+                    Mask rules configured in Mask Rules Studio: @MaskRules.Count
+                </MudAlert>
 
                 <MudExpansionPanels>
                     <MudExpansionPanel Text="Comparison Options">
@@ -363,6 +367,9 @@
 
 @code {
     [Parameter] public EventCallback<MultiFolderComparisonResult> OnComparisonComplete { get; set; }
+    [Parameter] public string? SharedSelectedModelName { get; set; }
+    [Parameter] public EventCallback<string> SharedSelectedModelNameChanged { get; set; }
+    [Parameter] public List<MaskRuleDto> MaskRules { get; set; } = new();
     private const string CustomEndpointValue = "__custom__";
 
     private List<IBrowserFile>? selectedFiles;
@@ -430,7 +437,9 @@
         availableModels = DeserializationService.GetRegisteredModelNames().ToList();
         if (availableModels.Count > 0)
         {
-            selectedModelName = availableModels[0];
+            selectedModelName = !string.IsNullOrWhiteSpace(SharedSelectedModelName)
+                ? SharedSelectedModelName
+                : availableModels[0];
         }
         
         var options = EndpointOptions.Value;
@@ -450,6 +459,21 @@
 
         timeoutMs = Configuration.GetValue("RequestComparison:DefaultTimeoutMs", 30000);
         maxConcurrency = Configuration.GetValue("RequestComparison:MaxConcurrency", 64);
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (!string.IsNullOrWhiteSpace(SharedSelectedModelName)
+            && !string.Equals(selectedModelName, SharedSelectedModelName, StringComparison.Ordinal))
+        {
+            selectedModelName = SharedSelectedModelName;
+        }
+    }
+
+    private async Task HandleSelectedModelChanged(string value)
+    {
+        selectedModelName = value;
+        await SharedSelectedModelNameChanged.InvokeAsync(value);
     }
 
     private async Task HandleFileSelection(InputFileChangeEventArgs e)
@@ -556,11 +580,25 @@
                         IgnoreCompletely = r.IgnoreCompletely, 
                         IgnoreCollectionOrder = r.IgnoreCollectionOrder 
                     }).ToList(),
+                MaskRules = MaskRules.Where(r => !string.IsNullOrWhiteSpace(r.PropertyPath))
+                    .Select(r => new MaskRuleDto
+                    {
+                        PropertyPath = r.PropertyPath,
+                        PreserveLastCharacters = r.PreserveLastCharacters,
+                        MaskCharacter = string.IsNullOrWhiteSpace(r.MaskCharacter) ? "*" : r.MaskCharacter
+                    }).ToList(),
                 SmartIgnoreRules = new List<SmartIgnoreRuleDto>()
             };
 
             var createResponse = await http.PostAsJsonAsync("/api/requests/compare", request);
-            createResponse.EnsureSuccessStatusCode();
+            if (!createResponse.IsSuccessStatusCode)
+            {
+                var apiError = await createResponse.Content.ReadAsStringAsync();
+                errorMessage = string.IsNullOrWhiteSpace(apiError)
+                    ? $"Comparison failed: {createResponse.ReasonPhrase}"
+                    : apiError;
+                return;
+            }
             
             var createResult = await createResponse.Content.ReadFromJsonAsync<CreateJobResponse>();
             currentJobId = createResult?.JobId;

--- a/ComparisonTool.Web/Components/Pages/Home.razor
+++ b/ComparisonTool.Web/Components/Pages/Home.razor
@@ -371,6 +371,9 @@
             {
                 <RequestComparisonPanel @ref="requestComparisonPanel" 
                                         OnComparisonComplete="HandleRequestComparisonComplete"
+                                        SharedSelectedModelName="@RequestSelectedModelName"
+                                        SharedSelectedModelNameChanged="@(value => RequestSelectedModelName = value)"
+                                        MaskRules="@RequestMaskRules"
                                         OnPropertySelectorOpened="OpenRequestPropertySelector"
                                         OnTreePropertySelectorOpened="OpenRequestTreePropertySelector" />
                 
@@ -517,6 +520,13 @@
                 }
             }
         </MudTabPanel>
+        <MudTabPanel Text="Mask Rules Studio">
+            <MaskRulesStudio AvailableModelNames="@DeserializationService.GetRegisteredModelNames()"
+                             SelectedModelName="@RequestSelectedModelName"
+                             SelectedModelNameChanged="@(value => RequestSelectedModelName = value)"
+                             MaskRules="@RequestMaskRules"
+                             MaskRulesChanged="HandleRequestMaskRulesChanged" />
+        </MudTabPanel>
     </MudTabs>
 </MudStack>
 
@@ -570,6 +580,8 @@
     private RequestComparisonPanel requestComparisonPanel;
     private HierarchicalPropertySelector requestPropertySelector;
     private ObjectTreePropertySelector requestTreePropertySelector;
+    private string? RequestSelectedModelName { get; set; }
+    private List<MaskRuleDto> RequestMaskRules { get; set; } = new();
 
     private bool CanRunFolderComparison =>
         !string.IsNullOrEmpty(SelectedModelName) &&
@@ -602,6 +614,8 @@
                     IgnoreCollectionOrder = rule.IgnoreCollectionOrder,
                 })
                 .ToList();
+
+            RequestSelectedModelName = SelectedModelName;
         }
         catch (Exception ex)
         {
@@ -762,6 +776,13 @@
                 requestComparisonPanel.IgnoreRules.Remove(rule);
             }
         }
+    }
+
+    private Task HandleRequestMaskRulesChanged(List<MaskRuleDto> maskRules)
+    {
+        RequestMaskRules = maskRules;
+        StateHasChanged();
+        return Task.CompletedTask;
     }
     
     private async Task BrowseDirectory1()

--- a/ComparisonTool.Web/Program.cs
+++ b/ComparisonTool.Web/Program.cs
@@ -51,6 +51,7 @@ builder.Services.AddHttpClient("RequestComparison")
 builder.Services.AddSingleton<RequestFileParserService>();
 builder.Services.AddSingleton<RequestExecutionService>();
 builder.Services.AddSingleton<RawTextComparisonService>();
+builder.Services.AddSingleton<ResponseMaskingService>();
 builder.Services.AddSingleton<IComparisonProgressPublisher, SignalRProgressPublisher>();
 builder.Services.AddSingleton<RequestComparisonJobService>();
 builder.Services.AddScoped<ComparisonProgressService>();

--- a/ComparisonTool.Web/RequestComparisonApi.cs
+++ b/ComparisonTool.Web/RequestComparisonApi.cs
@@ -198,7 +198,15 @@ public static class RequestComparisonApi
             return Results.BadRequest("EndpointB must be a valid URL");
         }
 
-        var job = jobService.CreateJob(request);
+        RequestComparisonJob job;
+        try
+        {
+            job = jobService.CreateJob(request);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(ex.Message);
+        }
 
         // Publish initial progress event (best-effort, don't block job creation)
         try

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ comparisontool folder <expected-dir> <actual-dir> -m ComplexOrderResponse \
   -f Console Json Markdown Html --html-mode SingleFile -o ./reports
 ```
 
-**Request comparison** — fire requests at two endpoints and diff the responses (with ignore rules + content-type override):
+**Request comparison** — fire requests at two endpoints and diff the responses (with ignore rules, response masking, and content-type override):
 ```bash
 comparisontool request <request-dir> \
   -a https://host-a/api/endpoint \
@@ -132,6 +132,7 @@ comparisontool request <request-dir> \
   --range 1-500 \
   --soap-action "urn:YourSoapAction" \
   --ignore-rules ./ignore-rules.json \
+  --mask-rules ./mask-rules.json \
   --content-type application/json \
   --disable-truncation \
   --ignore-collection-order --ignore-trailing-whitespace-end --ignore-namespaces \
@@ -141,6 +142,8 @@ comparisontool request <request-dir> \
 `--soap-action` is optional. When provided, it sets the `SOAPAction` header for requests sent to both endpoints.
 
 `--range` is optional. It applies a 1-based inclusive ordinal slice after top-level eligible request files are sorted with ordinal filename ordering. For example, `--range 1-500` stages the first 500 eligible `xml`/`json`/`txt` request files, clamping the end when fewer files are available.
+
+`--mask-rules` is optional. It masks matched JSON/XML string properties in saved response files before comparison and report generation. This is intended for sensitive values such as payment-card fields. v1 masking is string-only and preserves the final `preserveLastCharacters` characters.
 
 For CI troubleshooting (for example Jenkins), use `--disable-truncation` to show full value bodies directly in generated reports and console output.
 
@@ -158,6 +161,22 @@ For CI troubleshooting (for example Jenkins), use `--disable-truncation` to show
     "propertyPath": "Order.Items",
     "ignoreCompletely": false,
     "ignoreCollectionOrder": true
+  }
+]
+```
+
+**Mask rules JSON** (array of `MaskRuleDto`):
+```json
+[
+  {
+    "propertyPath": "Order.Payments[*].CardNumber",
+    "preserveLastCharacters": 4,
+    "maskCharacter": "*"
+  },
+  {
+    "propertyPath": "Order.Customer.Email",
+    "preserveLastCharacters": 0,
+    "maskCharacter": "#"
   }
 ]
 ```


### PR DESCRIPTION
- Implemented MaskRulesStudio.razor for building and managing masking rules for request comparison.
- Introduced PropertyPathExplorer.cs to facilitate property path exploration and metadata retrieval.
- Integrated MudBlazor components for UI elements including selection, input, and display of mask rules.
- Added functionality for importing and exporting mask rules in JSON format.
- Implemented rule editing, adding, and removal features with validation.